### PR TITLE
Add HTTP redirect example.

### DIFF
--- a/samples/http_redirect/BUILD
+++ b/samples/http_redirect/BUILD
@@ -1,0 +1,38 @@
+load("//:plugins.bzl", "proxy_wasm_plugin_cpp", "proxy_wasm_plugin_rust")
+
+licenses(["notice"])  # Apache 2
+
+proxy_wasm_plugin_rust(
+    name = "plugin_rust.wasm",
+    srcs = ["plugin.rs"],
+    deps = [
+        "@proxy_wasm_rust_sdk//:proxy_wasm",
+        "@proxy_wasm_rust_sdk//bazel/cargo:log",
+    ],
+)
+
+proxy_wasm_plugin_cpp(
+    name = "plugin_cpp.wasm",
+    srcs = ["plugin.cc"],
+    deps = [
+        "@proxy_wasm_cpp_sdk//contrib:contrib_lib",
+    ],
+)
+
+cc_test(
+    name = "plugin_test",
+    srcs = ["test.cc"],
+    data = [
+        ":plugin_cpp.wasm",
+        ":plugin_rust.wasm",
+    ],
+    deps = [
+        "//test:framework",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_googletest//:gtest_main",
+        "@proxy_wasm_cpp_host//:base_lib",
+        "@proxy_wasm_cpp_host//:v8_lib",
+        "@proxy_wasm_cpp_host//test:utility_lib",
+    ],
+)

--- a/samples/http_redirect/plugin.cc
+++ b/samples/http_redirect/plugin.cc
@@ -1,0 +1,33 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "proxy_wasm_intrinsics.h"
+
+class MyHttpContext : public Context {
+ public:
+  explicit MyHttpContext(uint32_t id, RootContext* root) : Context(id, root) {}
+
+  FilterHeadersStatus onRequestHeaders(uint32_t headers,
+                                       bool end_of_stream) override {
+    auto msg = getRequestHeader("Redirect-Me");
+    if (msg && msg->view() == "true") {
+      sendLocalResponse(301, "", "", {{"Location", "http://www.example.com"}});
+      return FilterHeadersStatus::StopIteration;
+    }
+    return FilterHeadersStatus::Continue;
+  }
+};
+
+static RegisterContextFactory register_StaticContext(
+    CONTEXT_FACTORY(MyHttpContext), ROOT_FACTORY(RootContext));

--- a/samples/http_redirect/plugin.rs
+++ b/samples/http_redirect/plugin.rs
@@ -1,0 +1,37 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use proxy_wasm::traits::*;
+use proxy_wasm::types::*;
+
+proxy_wasm::main! {{
+    proxy_wasm::set_log_level(LogLevel::Trace);
+    proxy_wasm::set_http_context(|_, _| -> Box<dyn HttpContext> { Box::new(MyHttpContext) });
+}}
+
+struct MyHttpContext;
+
+impl Context for MyHttpContext {}
+
+impl HttpContext for MyHttpContext {
+    fn on_http_request_headers(&mut self, _: usize, _: bool) -> Action {
+        let msg = self.get_http_request_header("Redirect-Me");
+        if msg.unwrap_or_default() == "true" {
+            self.send_http_response(301, vec![("Location", "http://www.example.com")], None);
+            Action::Pause
+        } else {
+            Action::Continue
+        }
+    }
+}

--- a/samples/http_redirect/test.cc
+++ b/samples/http_redirect/test.cc
@@ -1,0 +1,57 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "include/proxy-wasm/exports.h"
+#include "include/proxy-wasm/wasm.h"
+#include "test/framework.h"
+
+using ::testing::ElementsAre;
+using ::testing::Pair;
+
+namespace service_extensions_samples {
+
+INSTANTIATE_TEST_SUITE_P(
+    EnginesAndPlugins, HttpTest,
+    ::testing::Combine(
+        ::testing::ValuesIn(proxy_wasm::getWasmEngines()),
+        ::testing::Values("samples/http_redirect/plugin_cpp.wasm",
+                          "samples/http_redirect/plugin_rust.wasm")));
+
+TEST_P(HttpTest, RunPlugin) {
+  // Create VM + load plugin.
+  ASSERT_TRUE(CreatePlugin(engine(), path()).ok());
+
+  // Create stream context.
+  auto http_context = TestHttpContext(handle_);
+
+  // Expect no-op if header not present.
+  auto res = http_context.SendRequestHeaders({});
+  EXPECT_EQ(res.http_code, 0);
+
+  // Send request with header set to false, expect no-op.
+  auto res1 = http_context.SendRequestHeaders({{"Redirect-Me", "false"}});
+  EXPECT_EQ(res1.http_code, 0);
+
+  // Send request with header set to true, expect redirect.
+  auto res2 = http_context.SendRequestHeaders({{"Redirect-Me", "true"}});
+  EXPECT_EQ(res2.http_code, 301);
+  EXPECT_THAT(res2.headers,
+              ElementsAre(Pair("Location", "http://www.example.com")));
+
+  EXPECT_FALSE(handle_->wasm()->isFailed());
+}
+
+}  // namespace service_extensions_samples


### PR DESCRIPTION
~Sends a redirect if the request includes a header `Redirect-Me: true`.~ Sends a redirect if the request path matches known values.