### PR TITLE
feat: Add header-checker-lint.yml

### DIFF
--- a/.github/header-checker-lint.yml
+++ b/.github/header-checker-lint.yml
@@ -1,0 +1,29 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# header-checker-lint: A GitHub App built with [Probot][probot] that
+#   ensures source files contain avalid license header.
+# https://github.com/googleapis/repo-automation-bots/tree/main/packages/header-checker-lint
+# Install: https://github.com/apps/license-header-lint-gcf
+
+allowedCopyrightHolders:
+  - "Google LLC"
+
+allowedLicenses:
+  - 'Apache-2.0'
+
+sourceFileExtensions:
+  - "bzl"
+  - "cc"
+  - "rs"


### PR DESCRIPTION
Add config file for Licence Header Checker Bot. This is to allows the licence header bot to check .cc, .rc and .bzl files

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
