### PR TITLE
Create a C++ sample for AB-testing plugin.

### DIFF
--- a/samples/ab_testing/BUILD
+++ b/samples/ab_testing/BUILD
@@ -1,0 +1,28 @@
+load("//:plugins.bzl", "proxy_wasm_plugin_cpp", "proxy_wasm_plugin_rust")
+
+licenses(["notice"])  # Apache 2
+
+proxy_wasm_plugin_cpp(
+    name = "plugin_cpp.wasm",
+    srcs = ["plugin.cc"],
+    deps = [
+        "@proxy_wasm_cpp_sdk//contrib:contrib_lib",
+    ],
+)
+
+cc_test(
+    name = "plugin_test",
+    srcs = ["test.cc"],
+    data = [
+        ":plugin_cpp.wasm",
+    ],
+    deps = [
+        "//test:framework",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_googletest//:gtest_main",
+        "@proxy_wasm_cpp_host//:base_lib",
+        "@proxy_wasm_cpp_host//:v8_lib",
+        "@proxy_wasm_cpp_host//test:utility_lib",
+    ],
+)

--- a/samples/ab_testing/plugin.cc
+++ b/samples/ab_testing/plugin.cc
@@ -1,0 +1,43 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <ctime>
+#include <string>
+
+#include "proxy_wasm_intrinsics.h"
+
+class MyHttpContext : public Context {
+ public:
+  explicit MyHttpContext(uint32_t id, RootContext* root) : Context(id, root) {}
+
+  FilterHeadersStatus onRequestHeaders(uint32_t headers,
+                                       bool end_of_stream) override {
+    std::string path = getRequestHeader(":path")->toString();
+
+    const std::string default_file = "/file1.blah";
+    const std::string experiment_file = "/file2.blah";
+    if (path.length() >= default_file.length() && std::equal(default_file.rbegin(), default_file.rend(), path.rbegin())) {
+      bool serve_alternative_file = (rand() % 2 == 1);
+      if (serve_alternative_file) {
+        const std::string truncated_path = path.substr(0, path.length() - default_file.length());
+        replaceRequestHeader(":path", truncated_path + experiment_file);
+      }
+    }
+
+    return FilterHeadersStatus::Continue;
+  }
+};
+
+static RegisterContextFactory register_StaticContext(
+    CONTEXT_FACTORY(MyHttpContext), ROOT_FACTORY(RootContext));

--- a/samples/ab_testing/test.cc
+++ b/samples/ab_testing/test.cc
@@ -1,0 +1,64 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "include/proxy-wasm/exports.h"
+#include "include/proxy-wasm/wasm.h"
+#include "test/framework.h"
+
+using ::testing::ElementsAre;
+using ::testing::IsSubsetOf;
+using ::testing::Pair;
+
+namespace service_extensions_samples {
+
+INSTANTIATE_TEST_SUITE_P(
+    EnginesAndPlugins, HttpTest,
+    ::testing::Combine(
+        ::testing::ValuesIn(proxy_wasm::getWasmEngines()),
+        ::testing::Values("samples/ab_testing/plugin_cpp.wasm")));
+
+TEST_P(HttpTest, RunPlugin) {
+  // Create VM + load plugin.
+  ASSERT_TRUE(CreatePlugin(engine(), path()).ok());
+
+  // Create stream context.
+  auto http_context = TestHttpContext(handle_);
+
+  // Send a request that is irrelevant to the A/B experiment. Expect the path to stay unchanged.
+  auto res1 = http_context.SendRequestHeaders({{":path", "example.com/123"}});
+  EXPECT_EQ(res1.http_code, 0);
+  EXPECT_THAT(res1.headers, ElementsAre(Pair(":path", "example.com/123")));
+
+  // Send requests relevant to the experiment until both branches are exercised.
+  bool file1_served = false;
+  bool file2_served = false;
+  while (!file1_served || !file2_served) {
+    auto res = http_context.SendRequestHeaders({{":path", "example.com/file1.blah"}});
+    EXPECT_EQ(res.http_code, 0);
+    std::string path = res.headers[":path"];
+    if (path == "example.com/file1.blah") {
+      EXPECT_THAT(res.headers, ElementsAre(Pair(":path", "example.com/file1.blah")));
+      file1_served = true;
+    } else {
+      EXPECT_THAT(res.headers, ElementsAre(Pair(":path", "example.com/file2.blah")));
+      file2_served = true;
+    }
+  }
+
+  EXPECT_FALSE(handle_->wasm()->isFailed());
+}
+
+}  // namespace service_extensions_samples


### PR DESCRIPTION
This plugin is a showcase A/B testing in action. There is 50% chance that a user is served file A and 50% chance that the user is served file B.

Technically, this is performed by updating the URL path depending on which scenario has been exercised.