### PR TITLE
Add sample for blocking a request with particular header.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ plugin. Extend them to fit your particular use case.
 *   [Add HTTP request & response headers](samples/add_header): Add a header on
     both the client request and server response paths. Also check for existing
     headers.
+*   [Block Request with Particular Header Value](samples/block_request): Deny
+    a request whenever it contains a paritcular header set to certain value.
 *   [Plugin config with a list of tokens to deny](samples/config_denylist): Deny
     a request whenever it contains a known bad token. Bad tokens are loaded at
     plugin initialization time from plugin configuration.

--- a/samples/block_requests/BUILD
+++ b/samples/block_requests/BUILD
@@ -1,0 +1,37 @@
+load("//:plugins.bzl", "proxy_wasm_plugin_cpp", "proxy_wasm_plugin_rust")
+
+licenses(["notice"])  # Apache 2
+
+proxy_wasm_plugin_rust(
+    name = "plugin_rust.wasm",
+    srcs = ["plugin.rs"],
+    deps = [
+        "@proxy_wasm_rust_sdk//:proxy_wasm",
+    ],
+)
+
+proxy_wasm_plugin_cpp(
+    name = "plugin_cpp.wasm",
+    srcs = ["plugin.cc"],
+    deps = [
+        "@proxy_wasm_cpp_sdk//contrib:contrib_lib",
+    ],
+)
+
+cc_test(
+    name = "plugin_test",
+    srcs = ["test.cc"],
+    data = [
+        ":plugin_cpp.wasm",
+        ":plugin_rust.wasm",
+    ],
+    deps = [
+        "//test:framework",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_googletest//:gtest_main",
+        "@proxy_wasm_cpp_host//:base_lib",
+        "@proxy_wasm_cpp_host//:v8_lib",
+        "@proxy_wasm_cpp_host//test:utility_lib",
+    ],
+)

--- a/samples/block_requests/plugin.cc
+++ b/samples/block_requests/plugin.cc
@@ -1,0 +1,40 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "proxy_wasm_intrinsics.h"
+#include <regex>
+
+class MyHttpContext : public Context {
+ public:
+  explicit MyHttpContext(uint32_t id, RootContext* root) : Context(id, root) {}
+
+  FilterHeadersStatus onRequestHeaders(uint32_t headers,
+                                       bool end_of_stream) override {
+    const auto& referer = getRequestHeader("Referer");
+
+    if (referer && referer->view() == "https://www.example.com/") {
+      sendLocalResponse(404, "", "Error - Not Found.\n", {});
+      return FilterHeadersStatus::StopAllIterationAndWatermark;
+    }
+    return FilterHeadersStatus::Continue;
+  }
+
+  FilterHeadersStatus onResponseHeaders(uint32_t headers,
+                                        bool end_of_stream) override {
+    return FilterHeadersStatus::Continue;
+  }
+};
+
+static RegisterContextFactory register_StaticContext(
+    CONTEXT_FACTORY(MyHttpContext), ROOT_FACTORY(RootContext));

--- a/samples/block_requests/plugin.rs
+++ b/samples/block_requests/plugin.rs
@@ -1,0 +1,41 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START serviceextensions_example_block_request]
+use proxy_wasm::traits::*;
+use proxy_wasm::types::*;
+
+proxy_wasm::main! {{
+    proxy_wasm::set_log_level(LogLevel::Trace);
+    proxy_wasm::set_http_context(|_, _| -> Box<dyn HttpContext> { Box::new(MyHttpContext) });
+}}
+
+struct MyHttpContext;
+
+impl Context for MyHttpContext {}
+
+impl HttpContext for MyHttpContext {
+    fn on_http_request_headers(&mut self, _: usize, _: bool) -> Action {
+        let referer_value = self.get_http_request_header("Referer");
+        if referer_value.unwrap_or_default() == "https://www.example.com/" {
+            self.send_http_response(404, vec![], Some(b"Error - Not Found.\n"));
+            return Action::Pause;
+        }
+        return Action::Continue;      
+    }
+    fn on_http_response_headers(&mut self, _: usize, _: bool) -> Action {
+        return Action::Continue;
+    }
+}
+// [END serviceextensions_example_block_request]

--- a/samples/block_requests/test.cc
+++ b/samples/block_requests/test.cc
@@ -1,0 +1,59 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "include/proxy-wasm/exports.h"
+#include "include/proxy-wasm/wasm.h"
+#include "test/framework.h"
+
+using ::testing::ElementsAre;
+using ::testing::Pair;
+
+namespace service_extensions_samples {
+
+INSTANTIATE_TEST_SUITE_P(
+    EnginesAndPlugins, HttpTest,
+    ::testing::Combine(
+        ::testing::ValuesIn(proxy_wasm::getWasmEngines()),
+        ::testing::Values("samples/block_requests/plugin_cpp.wasm",
+                          "samples/block_requests/plugin_rust.wasm")));
+
+TEST_P(HttpTest, RunPlugin) {
+  // Create VM + load plugin.
+  ASSERT_TRUE(CreatePlugin(engine(), path()).ok());
+
+  // Create stream context.
+  auto http_context = TestHttpContext(handle_);
+
+  // Send request with no referer. Expect nothing.
+  auto res1 = http_context.SendRequestHeaders({});
+  EXPECT_EQ(res1.http_code, 0);
+  EXPECT_THAT(res1.headers, ElementsAre());
+
+  // Send request with referer with a valid value.
+  auto res2 = http_context.SendRequestHeaders({{"Referer", "https://www.google.com/"}});
+  EXPECT_EQ(res2.http_code, 0);
+  EXPECT_THAT(res2.headers, ElementsAre(Pair("Referer", "https://www.google.com/")));
+
+  // Send request with referer set to the forbidden value.
+  auto res3 = http_context.SendRequestHeaders({{"Referer", "https://www.example.com/"}});
+  EXPECT_EQ(res3.http_code, 404);
+  EXPECT_EQ(res3.body, "Error - Not Found.\n");
+  EXPECT_THAT(res3.headers, ElementsAre());
+
+  EXPECT_FALSE(handle_->wasm()->isFailed());
+}
+
+}  // namespace service_extensions_samples


### PR DESCRIPTION
Add a sample that checks the client referer header for a bad value, serve a synthetic 404 block with a basic html response (error not found).

- [ X] Tests pass
- [X ] Appropriate changes to documentation are included in the PR
