### PR TITLE
docs: add region tags for add_header example

### DIFF
--- a/samples/add_header/plugin.cc
+++ b/samples/add_header/plugin.cc
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// [START serviceextensions_add_header]
 #include "proxy_wasm_intrinsics.h"
 
 class MyHttpContext : public Context {
@@ -38,3 +39,4 @@ class MyHttpContext : public Context {
 
 static RegisterContextFactory register_StaticContext(
     CONTEXT_FACTORY(MyHttpContext), ROOT_FACTORY(RootContext));
+// [END serviceextensions_add_header]

--- a/samples/add_header/plugin.rs
+++ b/samples/add_header/plugin.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// [START serviceextensions_example_add_header]
+// [START serviceextensions_add_header]
 use proxy_wasm::traits::*;
 use proxy_wasm::types::*;
 
@@ -41,4 +41,4 @@ impl HttpContext for MyHttpContext {
         return Action::Continue;
     }
 }
-// [END serviceextensions_example_add_header]
+// [END serviceextensions_add_header]


### PR DESCRIPTION
Purpose: To add region tags comments for the purpose of embedding code in Cloud Docs.

The new region tag is `serviceextensions_add_header`. This region tag is create from a string concatenation of repo name(`serviceextensions_`) and sample's folder name(`add_header`).

New region tags are added to the following files
* samples/add_header/plugin.cc#L15
* samples/add_header/plugin.rs#L15
