### PR TITLE
feat: Add benchmarking support to the samples repository

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -22,6 +22,34 @@ build --action_env=BAZEL_COMPILER=clang
 build --action_env=CC=clang
 build --action_env=CXX=clang++
 
+# Common flags for Clang sanitizers.
+build:clang-xsan --copt -O1
+build:clang-xsan --copt -fno-omit-frame-pointer
+build:clang-xsan --copt -fno-optimize-sibling-calls
+build:clang-xsan --copt -fno-sanitize-recover=all
+build:clang-xsan --linkopt -fsanitize-link-c++-runtime
+build:clang-xsan --linkopt -fuse-ld=lld
+build:clang-xsan --linkopt -rtlib=compiler-rt
+build:clang-xsan --linkopt --unwindlib=libgcc
+
+# Use Clang compiler with Address and Undefined Behavior Sanitizers.
+build:clang-asan --config=clang-xsan
+build:clang-asan --copt -DADDRESS_SANITIZER=1
+build:clang-asan --copt -DUNDEFINED_SANITIZER=1
+build:clang-asan --copt -fsanitize=address,undefined
+build:clang-asan --copt -fsanitize-address-use-after-scope
+build:clang-asan --linkopt -fsanitize=address,undefined
+build:clang-asan --linkopt -fsanitize-address-use-after-scope
+build:clang-asan --test_env=ASAN_OPTIONS=check_initialization_order=1:detect_stack_use_after_return=1:strict_init_order=1:strict_string_checks=1
+build:clang-asan --test_env=UBSAN_OPTIONS=print_stacktrace=1
+build:clang-asan --test_env=ASAN_SYMBOLIZER_PATH
+
+# Use Clang compiler with Thread Sanitizer.
+build:clang-tsan --config=clang-xsan
+build:clang-tsan --copt -DTHREAD_SANITIZER=1
+build:clang-tsan --copt -fsanitize=thread
+build:clang-tsan --linkopt -fsanitize=thread
+
 # Set per-platform flags (used below).
 build --enable_platform_specific_config
 

--- a/.bazelrc
+++ b/.bazelrc
@@ -6,77 +6,23 @@
 # be overridden by specifying a different engine on the command line:
 # `bazel test //... --define engine=wasmtime` for example.
 build --define engine=v8
- 
+
+# For unit testing, remove randomness from BoringSSL.
+# This doesn't capture 'bazel run' test invocations. Oh well.
+test --per_file_copt=external/boringssl/.*@-DBORINGSSL_UNSAFE_DETERMINISTIC_MODE=1
+
+# For benchmarking, set specific build options.
+build:bench --define run_benchmarks=1
+build:bench --compilation_mode opt
+build:bench --dynamic_mode=off
+build:bench --copt -gmlt
+
 # Use Clang compiler.
 build --action_env=BAZEL_COMPILER=clang
 build --action_env=CC=clang
 build --action_env=CXX=clang++
 
-# Common flags for Clang sanitizers.
-build:clang-xsan --copt -O1
-build:clang-xsan --copt -fno-omit-frame-pointer
-build:clang-xsan --copt -fno-optimize-sibling-calls
-build:clang-xsan --copt -fno-sanitize-recover=all
-build:clang-xsan --linkopt -fsanitize-link-c++-runtime
-build:clang-xsan --linkopt -fuse-ld=lld
-build:clang-xsan --linkopt -rtlib=compiler-rt
-build:clang-xsan --linkopt --unwindlib=libgcc
-
-# Use Clang compiler with Address and Undefined Behavior Sanitizers.
-build:clang-asan --config=clang-xsan
-build:clang-asan --copt -DADDRESS_SANITIZER=1
-build:clang-asan --copt -DUNDEFINED_SANITIZER=1
-build:clang-asan --copt -fsanitize=address,undefined
-build:clang-asan --copt -fsanitize-address-use-after-scope
-build:clang-asan --linkopt -fsanitize=address,undefined
-build:clang-asan --linkopt -fsanitize-address-use-after-scope
-build:clang-asan --test_env=ASAN_OPTIONS=check_initialization_order=1:detect_stack_use_after_return=1:strict_init_order=1:strict_string_checks=1
-build:clang-asan --test_env=UBSAN_OPTIONS=print_stacktrace=1
-build:clang-asan --test_env=ASAN_SYMBOLIZER_PATH
-
-# Use Clang compiler with Address and Undefined Behavior Sanitizers (strict version).
-build:clang-asan-strict --config=clang-asan
-build:clang-asan-strict --copt -fsanitize=integer,local-bounds,nullability
-build:clang-asan-strict --linkopt -fsanitize=integer,local-bounds,nullability
-
-# Use Honggfuzz with Address and Undefined Behavior Sanitizers (strict version).
-build:clang-asan-honggfuzz --config=clang-asan-strict
-build:clang-asan-honggfuzz --@rules_fuzzing//fuzzing:cc_engine=@rules_fuzzing//fuzzing/engines:honggfuzz
-build:clang-asan-honggfuzz --@rules_fuzzing//fuzzing:cc_engine_instrumentation=honggfuzz
-
-# Use LibFuzzer with Address and Undefined Behavior Sanitizers (strict version).
-build:clang-asan-libfuzzer --config=clang-asan-strict
-build:clang-asan-libfuzzer --@rules_fuzzing//fuzzing:cc_engine=@rules_fuzzing//fuzzing/engines:libfuzzer
-build:clang-asan-libfuzzer --@rules_fuzzing//fuzzing:cc_engine_instrumentation=libfuzzer
-
-# Use Clang compiler with Thread Sanitizer.
-build:clang-tsan --config=clang-xsan
-build:clang-tsan --copt -DTHREAD_SANITIZER=1
-build:clang-tsan --copt -fsanitize=thread
-build:clang-tsan --linkopt -fsanitize=thread
-
-# Use Clang-Tidy tool.
-build:clang-tidy --aspects @bazel_clang_tidy//clang_tidy:clang_tidy.bzl%clang_tidy_aspect
-build:clang-tidy --@bazel_clang_tidy//:clang_tidy_config=@proxy_wasm_cpp_host//:clang_tidy_config
-build:clang-tidy --output_groups=report
-
-# Use GCC compiler.
-build:gcc --action_env=BAZEL_COMPILER=gcc
-build:gcc --action_env=CC=gcc
-build:gcc --action_env=CXX=g++
-
-# Use Zig C/C++ compiler.
-build:zig-cc --incompatible_enable_cc_toolchain_resolution
-build:zig-cc --extra_toolchains @zig_sdk//:aarch64-linux-gnu.2.28_toolchain
-build:zig-cc --extra_toolchains @zig_sdk//:x86_64-linux-gnu.2.28_toolchain
-build:zig-cc --host_copt=-fno-sanitize=undefined
-
-# Use Zig C/C++ compiler (cross-compile to Linux/aarch64).
-build:zig-cc-linux-aarch64 --config=zig-cc
-build:zig-cc-linux-aarch64 --platforms @zig_sdk//:linux_aarch64_platform
-build:zig-cc-linux-aarch64 --run_under=qemu-aarch64-static
-build:zig-cc-linux-aarch64 --test_env=QEMU_LD_PREFIX=/usr/aarch64-linux-gnu/
-
+# Set per-platform flags (used below).
 build --enable_platform_specific_config
 
 # Use C++17.

--- a/.bazelrc
+++ b/.bazelrc
@@ -16,6 +16,7 @@ build:bench --define run_benchmarks=1
 build:bench --compilation_mode opt
 build:bench --dynamic_mode=off
 build:bench --copt -gmlt
+build:bench --copt -DPROXY_WASM_TEST_SKIP_LOGS=1
 
 # Use Clang compiler.
 build --action_env=BAZEL_COMPILER=clang

--- a/BUILD
+++ b/BUILD
@@ -6,3 +6,8 @@ cc_library(
     deps = ["@boost//:throw_exception"],
     alwayslink = 1,
 )
+
+config_setting(
+    name = "benchmarks",
+    values = {"define": "run_benchmarks=1"},
+)

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ plugin. Extend them to fit your particular use case.
 # Feature set / ABI
 
 Service Extensions are compiled against the ProxyWasm ABI, described here:
-https://github.com/proxy-wasm/spec/tree/master/abi-versions/vNEXT
+https://github.com/proxy-wasm/spec/tree/master
 
 Service Extensions currently support a subset of the ProxyWasm spec. Support
 will grow over time. The current feature set includes:
@@ -107,7 +107,5 @@ Contributions welcome! See the [Contributing Guide](/docs/CONTRIBUTING.md).
 
 # TODO
 
-*   Write more plugin examples
-*   Set up CI for repository
-*   Publish and document the latest ProxyWasm version (not vNEXT as above)
+*   Write more plugin samples
 *   Add Golang recipes: https://github.com/tetratelabs/proxy-wasm-go-sdk

--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ Build all plugins and run all plugin tests:
 
 `$ bazelisk test --test_output=all //samples/...`
 
+Build and run benchmarks for a plugin:
+
+`$ bazelisk run --config=bench //samples/add_header:plugin_test`
+
 # Samples & Recipes
 
 The samples folder contains Samples & Recipes to use as a reference for your own

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -26,6 +26,13 @@ http_archive(
     url = "https://github.com/proxy-wasm/proxy-wasm-cpp-sdk/archive/" + PROXY_WASM_CPP_COMMIT + ".tar.gz",
 )
 
+http_archive(
+  name = "com_google_benchmark",
+  sha256 = "6bc180a57d23d4d9515519f92b0c83d61b05b5bab188961f36ac7b06b0d9e9ce",
+  urls = ["https://github.com/google/benchmark/archive/refs/tags/v1.8.3.tar.gz"],
+  strip_prefix = "benchmark-1.8.3",
+)
+
 # rules_boost on 2023-06-29, boost @ 1.80.0
 http_archive(
     name = "com_github_nelhage_rules_boost",

--- a/plugins.bzl
+++ b/plugins.bzl
@@ -16,6 +16,7 @@
 
 load("@proxy_wasm_cpp_host//bazel:wasm.bzl", "wasm_rust_binary")
 load("@proxy_wasm_cpp_sdk//bazel:defs.bzl", "proxy_wasm_cc_binary")
+load("@rules_cc//cc:defs.bzl", "cc_test")
 
 def proxy_wasm_plugin_rust(**kwargs):
     wasm_rust_binary(
@@ -30,5 +31,17 @@ def proxy_wasm_plugin_rust(**kwargs):
 
 def proxy_wasm_plugin_cpp(**kwargs):
     proxy_wasm_cc_binary(
+        **kwargs
+    )
+
+def proxy_wasm_test(deps = [], **kwargs):
+    cc_test(
+        deps = deps + [
+            "@com_google_benchmark//:benchmark",
+            "@com_google_googletest//:gtest",
+        ] + select({
+            "//:benchmarks": ["@com_google_benchmark//:benchmark_main"],
+            "//conditions:default": ["@com_google_googletest//:gtest_main"],
+        }),
         **kwargs
     )

--- a/samples/add_header/BUILD
+++ b/samples/add_header/BUILD
@@ -1,4 +1,4 @@
-load("//:plugins.bzl", "proxy_wasm_plugin_cpp", "proxy_wasm_plugin_rust")
+load("//:plugins.bzl", "proxy_wasm_plugin_cpp", "proxy_wasm_plugin_rust", "proxy_wasm_test")
 
 licenses(["notice"])  # Apache 2
 
@@ -19,7 +19,7 @@ proxy_wasm_plugin_cpp(
     ],
 )
 
-cc_test(
+proxy_wasm_test(
     name = "plugin_test",
     srcs = ["test.cc"],
     data = [
@@ -30,7 +30,6 @@ cc_test(
         "//test:framework",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
-        "@com_google_googletest//:gtest_main",
         "@proxy_wasm_cpp_host//:base_lib",
         "@proxy_wasm_cpp_host//:v8_lib",
         "@proxy_wasm_cpp_host//test:utility_lib",

--- a/samples/config_denylist/BUILD
+++ b/samples/config_denylist/BUILD
@@ -1,4 +1,4 @@
-load("//:plugins.bzl", "proxy_wasm_plugin_cpp", "proxy_wasm_plugin_rust")
+load("//:plugins.bzl", "proxy_wasm_plugin_cpp", "proxy_wasm_plugin_rust", "proxy_wasm_test")
 
 licenses(["notice"])  # Apache 2
 
@@ -19,7 +19,7 @@ proxy_wasm_plugin_cpp(
     ],
 )
 
-cc_test(
+proxy_wasm_test(
     name = "plugin_test",
     srcs = ["test.cc"],
     data = [
@@ -30,7 +30,6 @@ cc_test(
         "//test:framework",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
-        "@com_google_googletest//:gtest_main",
         "@proxy_wasm_cpp_host//:base_lib",
         "@proxy_wasm_cpp_host//:v8_lib",
         "@proxy_wasm_cpp_host//test:utility_lib",

--- a/samples/config_denylist/test.cc
+++ b/samples/config_denylist/test.cc
@@ -23,12 +23,7 @@ using ::testing::Pair;
 
 namespace service_extensions_samples {
 
-INSTANTIATE_TEST_SUITE_P(
-    EnginesAndPlugins, HttpTest,
-    ::testing::Combine(
-        ::testing::ValuesIn(proxy_wasm::getWasmEngines()),
-        ::testing::Values("samples/config_denylist/plugin_cpp.wasm",
-                          "samples/config_denylist/plugin_rust.wasm")));
+REGISTER_TESTS(HttpTest);
 
 TEST_P(HttpTest, NoConfig) {
   // Create VM and load the plugin.

--- a/samples/noop_logs/BUILD
+++ b/samples/noop_logs/BUILD
@@ -1,4 +1,4 @@
-load("//:plugins.bzl", "proxy_wasm_plugin_cpp", "proxy_wasm_plugin_rust")
+load("//:plugins.bzl", "proxy_wasm_plugin_cpp", "proxy_wasm_plugin_rust", "proxy_wasm_test")
 
 licenses(["notice"])  # Apache 2
 
@@ -19,7 +19,7 @@ proxy_wasm_plugin_cpp(
     ],
 )
 
-cc_test(
+proxy_wasm_test(
     name = "plugin_test",
     srcs = ["test.cc"],
     data = [
@@ -30,7 +30,6 @@ cc_test(
         "//test:framework",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
-        "@com_google_googletest//:gtest_main",
         "@proxy_wasm_cpp_host//:base_lib",
         "@proxy_wasm_cpp_host//:v8_lib",
         "@proxy_wasm_cpp_host//test:utility_lib",

--- a/samples/noop_logs/test.cc
+++ b/samples/noop_logs/test.cc
@@ -23,12 +23,7 @@ using ::testing::Pair;
 
 namespace service_extensions_samples {
 
-INSTANTIATE_TEST_SUITE_P(
-    EnginesAndPlugins, HttpTest,
-    ::testing::Combine(
-        ::testing::ValuesIn(proxy_wasm::getWasmEngines()),
-        ::testing::Values("samples/noop_logs/plugin_cpp.wasm",
-                          "samples/noop_logs/plugin_rust.wasm")));
+REGISTER_TESTS(HttpTest);
 
 TEST_P(HttpTest, RunPlugin) {
   // NOTE: This test should use mocks to verify logging order and counts.

--- a/samples/query_log/BUILD
+++ b/samples/query_log/BUILD
@@ -1,4 +1,4 @@
-load("//:plugins.bzl", "proxy_wasm_plugin_cpp", "proxy_wasm_plugin_rust")
+load("//:plugins.bzl", "proxy_wasm_plugin_cpp", "proxy_wasm_plugin_rust", "proxy_wasm_test")
 
 licenses(["notice"])  # Apache 2
 
@@ -22,7 +22,7 @@ proxy_wasm_plugin_cpp(
     ],
 )
 
-cc_test(
+proxy_wasm_test(
     name = "plugin_test",
     srcs = ["test.cc"],
     data = [
@@ -33,7 +33,6 @@ cc_test(
         "//test:framework",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
-        "@com_google_googletest//:gtest_main",
         "@proxy_wasm_cpp_host//:base_lib",
         "@proxy_wasm_cpp_host//:v8_lib",
         "@proxy_wasm_cpp_host//test:utility_lib",

--- a/samples/query_log/test.cc
+++ b/samples/query_log/test.cc
@@ -23,12 +23,7 @@ using ::testing::Pair;
 
 namespace service_extensions_samples {
 
-INSTANTIATE_TEST_SUITE_P(
-    EnginesAndPlugins, HttpTest,
-    ::testing::Combine(
-        ::testing::ValuesIn(proxy_wasm::getWasmEngines()),
-        ::testing::Values("samples/query_log/plugin_cpp.wasm",
-                          "samples/query_log/plugin_rust.wasm")));
+REGISTER_TESTS(HttpTest);
 
 TEST_P(HttpTest, RunPluginNoPathHeader) {
   // Create VM and load the plugin.

--- a/samples/regex_rewrite/BUILD
+++ b/samples/regex_rewrite/BUILD
@@ -1,4 +1,4 @@
-load("//:plugins.bzl", "proxy_wasm_plugin_cpp", "proxy_wasm_plugin_rust")
+load("//:plugins.bzl", "proxy_wasm_plugin_cpp", "proxy_wasm_plugin_rust", "proxy_wasm_test")
 
 licenses(["notice"])  # Apache 2
 
@@ -24,7 +24,7 @@ proxy_wasm_plugin_rust(
 #    ],
 #)
 
-cc_test(
+proxy_wasm_test(
     name = "plugin_test",
     srcs = ["test.cc"],
     data = [
@@ -35,7 +35,6 @@ cc_test(
         "//test:framework",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
-        "@com_google_googletest//:gtest_main",
         "@proxy_wasm_cpp_host//:base_lib",
         "@proxy_wasm_cpp_host//:v8_lib",
         "@proxy_wasm_cpp_host//test:utility_lib",

--- a/test/BUILD
+++ b/test/BUILD
@@ -5,9 +5,11 @@ package(default_visibility = ["//visibility:public"])
 cc_library(
     name = "framework",
     testonly = 1,
-    hdrs = ["framework.h"],
     srcs = ["framework.cc"],
+    hdrs = ["framework.h"],
     deps = [
+        "@boost//:dll",
+        "@boost//:filesystem",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
         "@com_google_googletest//:gtest",

--- a/test/BUILD
+++ b/test/BUILD
@@ -10,7 +10,7 @@ cc_library(
     deps = [
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
-        "@com_google_googletest//:gtest_main",
+        "@com_google_googletest//:gtest",
         "@proxy_wasm_cpp_host//:base_lib",
         "@proxy_wasm_cpp_host//test:utility_lib",
     ],

--- a/test/framework.cc
+++ b/test/framework.cc
@@ -14,7 +14,7 @@
 
 #include "test/framework.h"
 
-#include <filesystem>
+#include <boost/dll/runtime_symbol_info.hpp>
 
 namespace service_extensions_samples {
 
@@ -156,7 +156,8 @@ std::string ReadDataFile(const std::string& path) {
 
 std::vector<std::string> FindPlugins() {
   std::vector<std::string> out;
-  for (const auto& entry : std::filesystem::recursive_directory_iterator(".")) {
+  for (const auto& entry : boost::filesystem::directory_iterator(
+           boost::dll::program_location().parent_path())) {
     if (entry.path().extension() == ".wasm") {
       out.push_back(entry.path().string());
     }

--- a/test/framework.cc
+++ b/test/framework.cc
@@ -37,7 +37,7 @@ uint64_t TestContext::getMonotonicTimeNanoseconds() {
 }
 proxy_wasm::WasmResult TestContext::log(uint32_t log_level,
                                         std::string_view message) {
-#ifdef NDEBUG
+#ifdef PROXY_WASM_TEST_SKIP_LOGS
   // No logging in release mode (for benchmarks).
   return proxy_wasm::WasmResult::Ok;
 #else
@@ -172,7 +172,7 @@ CreateProxyWasmPlugin(const std::string& engine, const std::string& wasm_path,
 
   // Create a VM and load the plugin.
   auto vm = proxy_wasm::TestVm::makeVm(engine);
-#ifdef NDEBUG
+#ifdef PROXY_WASM_TEST_SKIP_LOGS
   // No tracing in release mode (for benchmarks).
   static_cast<proxy_wasm::TestIntegration*>(vm->integration().get())
       ->setLogLevel(proxy_wasm::LogLevel::critical);

--- a/test/framework.cc
+++ b/test/framework.cc
@@ -14,6 +14,8 @@
 
 #include "test/framework.h"
 
+#include <filesystem>
+
 namespace service_extensions_samples {
 
 proxy_wasm::BufferInterface* TestContext::getBuffer(
@@ -35,8 +37,13 @@ uint64_t TestContext::getMonotonicTimeNanoseconds() {
 }
 proxy_wasm::WasmResult TestContext::log(uint32_t log_level,
                                         std::string_view message) {
+#ifdef NDEBUG
+  // No logging in release mode (for benchmarks).
+  return proxy_wasm::WasmResult::Ok;
+#else
   std::cout << "LOG from testcontext: " << message << std::endl;
   return proxy_wasm::TestContext::log(log_level, message);
+#endif
 }
 
 proxy_wasm::WasmResult TestHttpContext::getHeaderMapSize(
@@ -137,14 +144,40 @@ TestHttpContext::Result TestHttpContext::SendResponseHeaders(
   return std::move(result_);
 }
 
-absl::Status HttpTest::CreatePlugin(const std::string& engine,
-                                    const std::string& wasm_path,
-                                    const std::string& plugin_config) {
+namespace {
+std::string ReadDataFile(const std::string& path) {
+  std::ifstream file(path, std::ios::binary);
+  EXPECT_FALSE(file.fail()) << "failed to open: " << path;
+  std::stringstream file_string_stream;
+  file_string_stream << file.rdbuf();
+  return file_string_stream.str();
+}
+}  // namespace
+
+std::vector<std::string> FindPlugins() {
+  std::vector<std::string> out;
+  for (const auto& entry : std::filesystem::recursive_directory_iterator(".")) {
+    if (entry.path().extension() == ".wasm") {
+      out.push_back(entry.path().string());
+    }
+  }
+  return out;
+}
+
+absl::StatusOr<std::shared_ptr<proxy_wasm::PluginHandleBase>>
+CreateProxyWasmPlugin(const std::string& engine, const std::string& wasm_path,
+                      const std::string& plugin_config) {
   // Read the wasm source.
   std::string wasm_module = ReadDataFile(wasm_path);
 
   // Create a VM and load the plugin.
   auto vm = proxy_wasm::TestVm::makeVm(engine);
+#ifdef NDEBUG
+  // No tracing in release mode (for benchmarks).
+  static_cast<proxy_wasm::TestIntegration*>(vm->integration().get())
+      ->setLogLevel(proxy_wasm::LogLevel::critical);
+#endif
+
   auto wasm = std::make_shared<TestWasm>(std::move(vm));
   if (!wasm->load(wasm_module, /*allow_precompiled=*/false)) {
     absl::string_view err = "Failed to load Wasm code";
@@ -174,19 +207,20 @@ absl::Status HttpTest::CreatePlugin(const std::string& engine,
     return absl::FailedPreconditionError("Plugin.configure failed");
   }
 
-  // Store pointers in handle_ property.
-  handle_ = std::make_shared<proxy_wasm::PluginHandleBase>(
+  // Return plugin handle.
+  return std::make_shared<proxy_wasm::PluginHandleBase>(
       std::make_shared<proxy_wasm::WasmHandleBase>(wasm), plugin);
-
-  return absl::OkStatus();
 }
 
-std::string HttpTest::ReadDataFile(const std::string& path) {
-  std::ifstream file(path, std::ios::binary);
-  EXPECT_FALSE(file.fail()) << "failed to open: " << path;
-  std::stringstream file_string_stream;
-  file_string_stream << file.rdbuf();
-  return file_string_stream.str();
+absl::Status HttpTest::CreatePlugin(const std::string& engine,
+                                    const std::string& wasm_path,
+                                    const std::string& plugin_config) {
+  auto handle_or = CreateProxyWasmPlugin(engine, wasm_path, plugin_config);
+  if (!handle_or.ok()) {
+    return handle_or.status();
+  }
+  handle_ = *handle_or;
+  return absl::OkStatus();
 }
 
 }  // namespace service_extensions_samples

--- a/test/framework.h
+++ b/test/framework.h
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#include <boost/filesystem/path.hpp>
+
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "gtest/gtest.h"
@@ -166,7 +168,7 @@ class TestWasm : public proxy_wasm::WasmBase {
   }
 };
 
-// Helper to scan for .wasm files in the current directory.
+// Helper to scan for .wasm files next to the executing binary.
 std::vector<std::string> FindPlugins();
 
 // Helper to initialize a VM + load a plugin.
@@ -212,17 +214,17 @@ class HttpTest
 
 // Helper to register a benchmark to run for all engines and plugins.
 // Consider adding Apply(cb) to allow callers to configure benchmarks.
-#define REGISTER_BENCH(fn)                                             \
-  struct Register_##fn {                                               \
-    Register_##fn() {                                                  \
-      for (auto& engine : proxy_wasm::getWasmEngines()) {              \
-        for (auto& plugin : FindPlugins()) {                           \
-          benchmark::RegisterBenchmark(                                \
-              absl::StrCat(#fn, "_", engine, "_", plugin), fn, engine, \
-              plugin);                                                 \
-        }                                                              \
-      }                                                                \
-    }                                                                  \
+#define REGISTER_BENCH(fn)                                                    \
+  struct Register_##fn {                                                      \
+    Register_##fn() {                                                         \
+      for (auto& engine : proxy_wasm::getWasmEngines()) {                     \
+        for (auto& plugin : FindPlugins()) {                                  \
+          auto file = boost::filesystem::path(plugin).filename().string();    \
+          benchmark::RegisterBenchmark(                                       \
+              absl::StrCat(#fn, "_", engine, "_", file), fn, engine, plugin); \
+        }                                                                     \
+      }                                                                       \
+    }                                                                         \
   } register_##fn;
 
 }  // namespace service_extensions_samples


### PR DESCRIPTION
- rework .bazelrc: add benchmarking/testing flags, remove cruft
- add static registration macros for unit tests and benchmarks, so we automatically run them for all engines + plugin flavors
- add proxy_wasm_test macro to support tests + benchmarks in one file
- optimize the test framework for benchmarks (no logging, no tracing)
- write sample benchmarks for add_header and regex_rewrite
- update README with benchmarking command

I included a small unrelated change to neuter BoringSSL's RNG in tests.

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR
