### PR TITLE
docs: update region tags

### DIFF
--- a/plugins/samples/add_header/plugin.cc
+++ b/plugins/samples/add_header/plugin.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// [START serviceextensions_add_header]
+// [START serviceextensions_plugin_add_header]
 #include "proxy_wasm_intrinsics.h"
 
 class MyHttpContext : public Context {
@@ -39,4 +39,4 @@ class MyHttpContext : public Context {
 
 static RegisterContextFactory register_StaticContext(
     CONTEXT_FACTORY(MyHttpContext), ROOT_FACTORY(RootContext));
-// [END serviceextensions_add_header]
+// [END serviceextensions_plugin_add_header]

--- a/plugins/samples/add_header/plugin.rs
+++ b/plugins/samples/add_header/plugin.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// [START serviceextensions_add_header]
+// [START serviceextensions_plugin_add_header]
 use proxy_wasm::traits::*;
 use proxy_wasm::types::*;
 
@@ -41,4 +41,4 @@ impl HttpContext for MyHttpContext {
         return Action::Continue;
     }
 }
-// [END serviceextensions_add_header]
+// [END serviceextensions_plugin_add_header]

--- a/plugins/samples/config_denylist/plugin.cc
+++ b/plugins/samples/config_denylist/plugin.cc
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// [START serviceextensions_plugin_example_config_denylist]
 #include <unordered_set>
 
 #include "proxy_wasm_intrinsics.h"
@@ -81,3 +82,4 @@ class MyHttpContext : public Context {
 
 static RegisterContextFactory register_StaticContext(
     CONTEXT_FACTORY(MyHttpContext), ROOT_FACTORY(MyRootContext));
+// [END serviceextensions_plugin_example_config_denylist]

--- a/plugins/samples/config_denylist/plugin.rs
+++ b/plugins/samples/config_denylist/plugin.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// [START serviceextensions_example_config_denylist]
+// [START serviceextensions_plugin_example_config_denylist]
 use log::*;
 use proxy_wasm::traits::*;
 use proxy_wasm::types::*;
@@ -93,4 +93,4 @@ impl HttpContext for MyHttpContext {
         return Action::Continue;
     }
 }
-// [END serviceextensions_example_config_denylist]
+// [END serviceextensions_plugin_example_config_denylist]

--- a/plugins/samples/noop_logs/plugin.cc
+++ b/plugins/samples/noop_logs/plugin.cc
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// [START serviceextensions_plugin_example_noop_logs]
 #include "proxy_wasm_intrinsics.h"
 
 class MyRootContext : public RootContext {
@@ -58,3 +59,4 @@ class MyHttpContext : public Context {
 
 static RegisterContextFactory register_StaticContext(
     CONTEXT_FACTORY(MyHttpContext), ROOT_FACTORY(MyRootContext));
+// [END serviceextensions_plugin_example_noop_logs]

--- a/plugins/samples/noop_logs/plugin.rs
+++ b/plugins/samples/noop_logs/plugin.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// [START serviceextensions_example_noop_logs]
+// [START serviceextensions_plugin_example_noop_logs]
 use log::info;
 use proxy_wasm::traits::*;
 use proxy_wasm::types::*;
@@ -80,4 +80,4 @@ impl HttpContext for MyHttpContext {
         return Action::Continue;
     }
 }
-// [END serviceextensions_example_noop_logs]
+// [END serviceextensions_plugin_example_noop_logs]

--- a/plugins/samples/query_log/plugin.cc
+++ b/plugins/samples/query_log/plugin.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// [START serviceextensions_query_log]
+// [START serviceextensions_plugin_query_log]
 #include <boost/url/parse.hpp>
 #include <boost/url/url.hpp>
 
@@ -43,4 +43,4 @@ class MyHttpContext : public Context {
 
 static RegisterContextFactory register_StaticContext(
     CONTEXT_FACTORY(MyHttpContext), ROOT_FACTORY(RootContext));
-// [END serviceextensions_query_log]
+// [END serviceextensions_plugin_query_log]

--- a/plugins/samples/query_log/plugin.rs
+++ b/plugins/samples/query_log/plugin.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// [START serviceextensions_query_log]
+// [START serviceextensions_plugin_query_log]
 use log::info;
 use proxy_wasm::traits::*;
 use proxy_wasm::types::*;
@@ -48,4 +48,4 @@ impl HttpContext for MyHttpContext {
         return Action::Continue;
     }
 }
-// [END serviceextensions_query_log]
+// [END serviceextensions_plugin_query_log]

--- a/plugins/samples/regex_rewrite/plugin.cc
+++ b/plugins/samples/regex_rewrite/plugin.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// [START serviceextensions_regex_rewrite]
+// [START serviceextensions_plugin_regex_rewrite]
 #include "proxy_wasm_intrinsics.h"
 #include "re2/re2.h"
 
@@ -53,4 +53,4 @@ class MyHttpContext : public Context {
 
 static RegisterContextFactory register_StaticContext(
     CONTEXT_FACTORY(MyHttpContext), ROOT_FACTORY(MyRootContext));
-// [END serviceextensions_regex_rewrite]
+// [END serviceextensions_plugin_regex_rewrite]

--- a/plugins/samples/regex_rewrite/plugin.rs
+++ b/plugins/samples/regex_rewrite/plugin.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// [START serviceextensions_regex_rewrite]
+// [START serviceextensions_plugin_regex_rewrite]
 use proxy_wasm::traits::*;
 use proxy_wasm::types::*;
 use regex::Regex;
@@ -65,4 +65,4 @@ impl HttpContext for MyHttpContext {
         return Action::Continue;
     }
 }
-// [END serviceextensions_regex_rewrite]
+// [END serviceextensions_plugin_regex_rewrite]


### PR DESCRIPTION
PR adds following docs changes & no code updates

1. Update region tags to include `plugin` key word
2. Add new region tags to code samples


Similar PR: https://github.com/GoogleCloudPlatform/python-docs-samples/pull/10916

Issue Request: https://github.com/GoogleCloudPlatform/python-docs-samples/issues/10788


This update can ensure that Callout and Plugin (add_header & other) samples are distinguishable by region tag name.