### PR TITLE
fix: treat header names as case insensitive

### DIFF
--- a/plugins/samples/add_header/plugin.cc
+++ b/plugins/samples/add_header/plugin.cc
@@ -23,6 +23,7 @@ class MyHttpContext : public Context {
                                        bool end_of_stream) override {
     // Always be a friendly proxy.
     addRequestHeader("Message", "hello");
+    replaceRequestHeader("Welcome", "warm");
     return FilterHeadersStatus::Continue;
   }
 
@@ -33,6 +34,8 @@ class MyHttpContext : public Context {
     if (msg && msg->view() == "foo") {
       addResponseHeader("Message", "bar");
     }
+    // Unconditionally remove a header.
+    removeResponseHeader("Welcome");
     return FilterHeadersStatus::Continue;
   }
 };

--- a/plugins/samples/add_header/plugin.rs
+++ b/plugins/samples/add_header/plugin.rs
@@ -29,6 +29,7 @@ impl HttpContext for MyHttpContext {
     fn on_http_request_headers(&mut self, _: usize, _: bool) -> Action {
         // Always be a friendly proxy.
         self.add_http_request_header("Message", "hello");
+        self.set_http_request_header("Welcome", Some("warm"));
         return Action::Continue;
     }
 
@@ -38,6 +39,8 @@ impl HttpContext for MyHttpContext {
         if msg.unwrap_or_default() == "foo" {
             self.add_http_response_header("Message", "bar");
         }
+        // Unconditionally remove a header.
+        self.set_http_response_header("Welcome", None);
         return Action::Continue;
     }
 }

--- a/plugins/samples/add_header/tests.textpb
+++ b/plugins/samples/add_header/tests.textpb
@@ -1,14 +1,23 @@
 test {
   name: "AddsRequestHeader"
   request_headers {
-    result { has_header { key: "Message" value: "hello" } }
+    result {
+      has_header { key: "Message" value: "hello" }
+      has_header { key: "Welcome" value: "warm" }
+    }
   }
 }
 test {
-  name: "ExtendsRequestHeader"
+  name: "UpdatesRequestHeader"
   request_headers {
-    input { header { key: "Message" value: "hey" } }
-    result { has_header { key: "Message" value: "hey, hello" } }
+    input {
+      header { key: "Message" value: "hey" }
+      header { key: "Welcome" value: "cold" }
+    }
+    result {
+      has_header { key: "Message" value: "hey, hello" }
+      has_header { key: "Welcome" value: "warm" }
+    }
   }
 }
 test {
@@ -32,6 +41,14 @@ test {
   }
 }
 test {
+  name: "RemovesResponseHeader"
+  response_headers {
+    input { header { key: "Welcome" value: "any" } }
+    result { no_header { key: "Welcome" } }
+  }
+}
+# Behavior is independent of stream.
+test {
   name: "RequestAndResponse"
   request_headers {
     result { has_header { key: "Message" value: "hello" } }
@@ -39,5 +56,40 @@ test {
   response_headers {
     input { header { key: "Message" value: "foo" } }
     result { has_header { key: "Message" value: "foo, bar" } }
+  }
+}
+# Tests for header name case insensitivity.
+test {
+  name: "CaseInsensitiveTest"
+  request_headers {
+    # Test framework itself doesn't distinguish case.
+    result { has_header { key: "message" value: "hello" } }
+  }
+}
+test {
+  name: "CaseInsensitiveUpdates"
+  request_headers {
+    input {
+      header { key: "message" value: "hey" }
+      header { key: "welcome" value: "cold" }
+    }
+    result {
+      has_header { key: "message" value: "hey, hello" }
+      has_header { key: "welcome" value: "warm" }
+    }
+  }
+}
+test {
+  name: "CaseInsensitiveLookup"
+  response_headers {
+    input { header { key: "message" value: "foo" } }
+    result { has_header { key: "message" value: "foo, bar" } }
+  }
+}
+test {
+  name: "CaseInsensitiveRemoval"
+  response_headers {
+    input { header { key: "welcome" value: "any" } }
+    result { no_header { key: "welcome" } }
   }
 }

--- a/plugins/samples/add_header/tests.textpb
+++ b/plugins/samples/add_header/tests.textpb
@@ -59,13 +59,10 @@ test {
   }
 }
 # Tests for header name case insensitivity.
-test {
-  name: "CaseInsensitiveTest"
-  request_headers {
-    # Test framework itself doesn't distinguish case.
-    result { has_header { key: "message" value: "hello" } }
-  }
-}
+# NOTE: the test framework uses the same case-insensitive header map as the
+# wasm host context. This means a header key has the case used when it was
+# first created. It also means that we can't test casing in our expectations.
+# Here we are simply verifying that the wasm behavior is unaffected by case.
 test {
   name: "CaseInsensitiveUpdates"
   request_headers {

--- a/plugins/test/BUILD
+++ b/plugins/test/BUILD
@@ -8,6 +8,7 @@ cc_library(
     srcs = ["framework.cc"],
     hdrs = ["framework.h"],
     deps = [
+        "@boost//:algorithm",
         "@boost//:dll",
         "@boost//:filesystem",
         "@com_google_absl//absl/status",

--- a/plugins/test/framework.h
+++ b/plugins/test/framework.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <boost/algorithm/string.hpp>
 #include <boost/filesystem/path.hpp>
 
 #include "absl/status/status.h"
@@ -81,7 +82,6 @@ class TestContext : public proxy_wasm::TestContext {
 //
 // The implementation is an incomplete test-only approximation of HTTP-compliant
 // header handling. It's missing at least the following:
-// - case insensitivity
 // - cookie handling
 // - restricted header checks
 // - empty value checks
@@ -136,8 +136,18 @@ class TestHttpContext : public TestContext {
                                            std::string_view details) override;
   // --- END Wasm facing API ---
 
-  // Testing types. Optimized for ease of use not performance.
-  using Headers = std::map<std::string, std::string>;  // key-sorted map
+  // Testing types. Optimized for ease of use, not performance.
+
+  // Case insensitive string comparator.
+  struct caseless_compare {
+    bool operator()(const std::string& a, const std::string& b) const {
+      return boost::ilexicographical_compare(a, b);
+    }
+  };
+
+  // Key-sorted header map with case-insensitive key comparison.
+  using Headers = std::map<std::string, std::string, caseless_compare>;
+
   struct Result {
     // Filter status returned by handler.
     proxy_wasm::FilterHeadersStatus status;

--- a/plugins/test/runner.proto
+++ b/plugins/test/runner.proto
@@ -37,7 +37,7 @@ message Header {
 
 message Input {
   // Set of key-value headers. Includes pseudo-headers (e.g. :path).
-  // Reading header names is case-insensitive (TODO: fix issue #9).
+  // Looking up header names (keys) is case-insensitive.
   repeated Header header = 1;
 
   // HTTP BODY raw content.


### PR DESCRIPTION
Also expand header mutation testing (include updates, removals).

Branched off #38. Fixes #9.

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR
