### PR TITLE
fix: Better handling for VM/stream failures.

### DIFF
--- a/plugins/test/framework.h
+++ b/plugins/test/framework.h
@@ -129,6 +129,8 @@ class TestHttpContext : public TestContext {
       proxy_wasm::WasmHeaderMapType type,
       const proxy_wasm::Pairs& pairs) override;
 
+  // Ignore failStream, avoid calling unimplemented closeStream.
+  void failStream(proxy_wasm::WasmStreamType) override {}
   proxy_wasm::WasmResult sendLocalResponse(uint32_t response_code,
                                            std::string_view body_text,
                                            proxy_wasm::Pairs additional_headers,


### PR DESCRIPTION
Without this fix the context calls closeStream() which aborts with an "unimplemented" error.

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR
