### PR TITLE
feat: Adding new sample for the python callouts

### DIFF
--- a/callouts/python/extproc/example/add_header/service_callout_example.py
+++ b/callouts/python/extproc/example/add_header/service_callout_example.py
@@ -15,6 +15,7 @@
 from grpc import ServicerContext
 from envoy.service.ext_proc.v3 import external_processor_pb2 as service_pb2
 from extproc.service import callout_server
+from extproc.service import callout_tools
 
 
 class CalloutServerExample(callout_server.CalloutServer):
@@ -33,7 +34,7 @@ class CalloutServerExample(callout_server.CalloutServer):
       self, headers: service_pb2.HttpHeaders, context: ServicerContext
   ) -> service_pb2.HeadersResponse:
     """Custom processor on request headers."""
-    return callout_server.add_header_mutation(
+    return callout_tools.add_header_mutation(
       add=[('header-request', 'request')],
       clear_route_cache=True
     )
@@ -42,7 +43,7 @@ class CalloutServerExample(callout_server.CalloutServer):
       self, headers: service_pb2.HttpHeaders, context: ServicerContext
   ) -> service_pb2.HeadersResponse:
     """Custom processor on response headers."""
-    return callout_server.add_header_mutation(
+    return callout_tools.add_header_mutation(
       add=[('header-response', 'response')],
       remove=['foo']
     )

--- a/callouts/python/extproc/example/redirect/Dockerfile
+++ b/callouts/python/extproc/example/redirect/Dockerfile
@@ -1,0 +1,22 @@
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+FROM service-callout-common-python
+
+# Copy over example specific files.
+COPY extproc/example/redirect/*.py ./
+
+# Set up communication ports.
+EXPOSE 443
+EXPOSE 8080
+EXPOSE 80
+
+# Start the service.
+CMD [ "/usr/bin/python3", "-um", "service_callout_example" ]

--- a/callouts/python/extproc/example/redirect/service_callout_example.py
+++ b/callouts/python/extproc/example/redirect/service_callout_example.py
@@ -1,0 +1,41 @@
+# Copyright 2024 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from grpc import ServicerContext
+from envoy.service.ext_proc.v3 import external_processor_pb2 as service_pb2
+from extproc.service import callout_server
+from extproc.service import callout_tools
+
+class CalloutServerExample(callout_server.CalloutServer):
+  """Example callout server.
+
+  Provides a non-comprehensive set of responses for each of the possible
+  callout interactions.
+
+  On a request header callout we perform a redirect to '{http://service-extensions.com/redirect}'
+  with the status of '{301}' - MovedPermanently returning an ImmediateResponse
+  """
+
+  def on_request_headers(
+      self, headers: service_pb2.HttpHeaders, context: ServicerContext
+  ) -> service_pb2.ImmediateResponse:
+    """Custom processor on request headers."""
+    return callout_tools.header_immediate_response(
+      status=301,
+      headers=[('Location', 'http://service-extensions.com/redirect')]
+    )
+
+if __name__ == '__main__':
+  # Run the gRPC service
+  CalloutServerExample(port=443, insecure_port=8080, health_check_port=80).run()

--- a/callouts/python/extproc/service/callout_server.py
+++ b/callouts/python/extproc/service/callout_server.py
@@ -205,11 +205,16 @@ class CalloutServer:
     """Process the client request."""
     for request in request_iterator:
       if request.HasField('request_headers'):
-        yield service_pb2.ProcessingResponse(
-            request_headers=self.on_request_headers(
-                request.request_headers, context
-            )
-        )
+        response = self.on_request_headers(request.request_headers, context)
+
+        if isinstance(response, service_pb2.ImmediateResponse):
+          yield service_pb2.ProcessingResponse(
+            immediate_response=response
+          )
+        elif isinstance(response, service_pb2.HeadersResponse):
+          yield service_pb2.ProcessingResponse(
+            request_headers=response
+          )
       if request.HasField('response_headers'):
         yield service_pb2.ProcessingResponse(
             response_headers=self.on_response_headers(

--- a/callouts/python/extproc/tests/redirect_test.py
+++ b/callouts/python/extproc/tests/redirect_test.py
@@ -1,0 +1,72 @@
+# Copyright 2024 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import print_function
+import threading
+
+from envoy.config.core.v3.base_pb2 import HeaderMap
+from envoy.config.core.v3.base_pb2 import HeaderValue
+from envoy.service.ext_proc.v3 import external_processor_pb2 as service_pb2
+from envoy.service.ext_proc.v3 import external_processor_pb2_grpc as service_pb2_grpc
+import grpc
+import pytest
+
+from extproc.example.redirect.service_callout_example import (
+  CalloutServerExample as CalloutServerTest,
+)
+from extproc.service import callout_server
+from extproc.service.callout_tools import header_immediate_response
+from extproc.tests.basic_grpc_test import _make_request, _wait_till_server
+
+# Global server variable.
+server: callout_server.CalloutServer | None = None
+
+@pytest.fixture(scope='class')
+def setup_and_teardown():
+  global server
+  try:
+    server = CalloutServerTest()
+    # Start the server in a background thread
+    thread = threading.Thread(target=server.run)
+    thread.daemon = True
+    thread.start()
+    # Wait for the server to start
+    _wait_till_server(lambda: server and server._setup)
+    yield
+    # Stop the server
+    server.shutdown()
+    thread.join(timeout=5)
+  finally:
+    del server
+
+@pytest.mark.usefixtures('setup_and_teardown')
+def test_header_immediate_response() -> None:
+  with grpc.insecure_channel(f'0.0.0.0:{server.insecure_port}') as channel:
+    stub = service_pb2_grpc.ExternalProcessorStub(channel)
+
+    # Construct the HeaderMap
+    header_map = HeaderMap()
+    header_value = HeaderValue(key="header", raw_value=b"value")
+    header_map.headers.extend([header_value])
+
+    # Construct HttpHeaders with the HeaderMap
+    headers = service_pb2.HttpHeaders(headers=header_map,
+                                            end_of_stream=True)
+
+    response = _make_request(stub, request_headers=headers)
+
+    assert response.HasField('immediate_response')
+    assert response.immediate_response == header_immediate_response(
+      status=301,
+      headers=[('Location', 'http://service-extensions.com/redirect')])
+


### PR DESCRIPTION
Adding the redirect sample as a standalone example

## Use-cases
7. Perform a HTTP redirect

## Details
UC7 - For a given URL - redirect to another URL

New PR based on the new structure from #55 and requested changes in #53 to use ImmediateResponse
- Minor fix in the add_header to use the new callout_tools instead of callout_server