### PR TITLE
fix: Update CODEOWNERS to match directory shuffle

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,6 +2,6 @@
 *                 @GoogleCloudPlatform/service-extensions-samples-owners @GoogleCloudPlatform/dee-infra
 
 # Sample Reviewers
-callouts/         @GoogleCloudPlatform/service-extensions-samples-reviewers @upeeth
-plugins/          @GoogleCloudPlatform/service-extensions-samples-reviewers @upeeth
-README.md         @GoogleCloudPlatform/service-extensions-samples-reviewers @upeeth
+/callouts/        @GoogleCloudPlatform/service-extensions-samples-reviewers @upeeth
+/plugins/         @GoogleCloudPlatform/service-extensions-samples-reviewers @upeeth
+/README.md        @GoogleCloudPlatform/service-extensions-samples-reviewers @upeeth

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,5 +2,6 @@
 *                 @GoogleCloudPlatform/service-extensions-samples-owners @GoogleCloudPlatform/dee-infra
 
 # Sample Reviewers
-samples/          @GoogleCloudPlatform/service-extensions-samples-reviewers @upeeth
+callouts/         @GoogleCloudPlatform/service-extensions-samples-reviewers @upeeth
+plugins/          @GoogleCloudPlatform/service-extensions-samples-reviewers @upeeth
 README.md         @GoogleCloudPlatform/service-extensions-samples-reviewers @upeeth


### PR DESCRIPTION
Fix CODEOWNERS reviewers to cover plugins/ and callouts/ samples dirs.