### PR TITLE
feat: Read serialized HTTP1 headers from string or file

### DIFF
--- a/plugins/README.md
+++ b/plugins/README.md
@@ -15,8 +15,8 @@ We recommend the following process:
     [Proxy-Wasm](https://github.com/proxy-wasm) SDKs as a starting point, write
     a wasm plugin in a language of your choice. Get it building.
 1.  Write a plugin test file (textproto) to specify the plugin's functional
-    expectations ([example](samples/config_denylist/tests.textpb)). Consult the
-    plugin tester [proto API](test/runner.proto) as needed.
+    expectations ([example](samples/testing/tests.textpb)). Consult the plugin
+    tester [proto API](test/runner.proto) as needed.
 1.  Add `benchmark: true` to tests that exemplify common wasm operations
     ([example](samples/add_header/tests.textpb)).
 1.  Run + Test + Benchmark your wasm plugin as follows!
@@ -31,8 +31,9 @@ docker run -it -v $(pwd):/mnt \
 Tips:
 
 -   When benchmarking and publishing, compile a release (optimized) wasm build.
--   To see a trace of logs and wasm ABI calls, add `--loglevel=TRACE`.
 -   Try sending empty or invalid input. Verify your plugin doesn't crash.
+-   To see plugin-emitted logs on the console, add `--logfile=/dev/stdout`.
+-   To see a trace of logs and wasm ABI calls, add `--loglevel=TRACE`.
 -   Optionally specify plugin config data using the `--config=<path>` flag.
 
 # Samples & Recipes
@@ -40,6 +41,8 @@ Tips:
 The [samples](samples/) folder contains Samples & Recipes to use as a reference
 for your own plugin. Extend them to fit your particular use case.
 
+*   [Testing examples](samples/testing): A demonstration of our test framework
+    capabilities (sending inputs and checking results).
 *   [Log each Wasm call](samples/noop_logs): Don't change anything about the
     traffic (noop plugin). Log each wasm invocation, including lifecycle
     callbacks.

--- a/plugins/WORKSPACE
+++ b/plugins/WORKSPACE
@@ -27,19 +27,20 @@ http_archive(
 )
 
 http_archive(
-  name = "com_google_benchmark",
-  sha256 = "6bc180a57d23d4d9515519f92b0c83d61b05b5bab188961f36ac7b06b0d9e9ce",
-  urls = ["https://github.com/google/benchmark/archive/refs/tags/v1.8.3.tar.gz"],
-  strip_prefix = "benchmark-1.8.3",
+    name = "com_google_benchmark",
+    sha256 = "6bc180a57d23d4d9515519f92b0c83d61b05b5bab188961f36ac7b06b0d9e9ce",
+    strip_prefix = "benchmark-1.8.3",
+    urls = ["https://github.com/google/benchmark/archive/refs/tags/v1.8.3.tar.gz"],
 )
 
 # rules_boost on 2023-06-29, boost @ 1.80.0
 http_archive(
     name = "com_github_nelhage_rules_boost",
-    url = "https://github.com/nelhage/rules_boost/archive/0598ab9aa992d6ad45088b480e1bf4526ef4ad04.tar.gz",
-    strip_prefix = "rules_boost-0598ab9aa992d6ad45088b480e1bf4526ef4ad04",
     sha256 = "1404ffb9f3f7253927c97bc2e05ef6b4a2a5089b76d00cef0f6b7d5a678fad88",
+    strip_prefix = "rules_boost-0598ab9aa992d6ad45088b480e1bf4526ef4ad04",
+    url = "https://github.com/nelhage/rules_boost/archive/0598ab9aa992d6ad45088b480e1bf4526ef4ad04.tar.gz",
 )
+
 load("@com_github_nelhage_rules_boost//:boost/boost.bzl", "boost_deps")
 boost_deps()
 
@@ -53,15 +54,30 @@ http_archive(
 
 # Upgrade Abseil to work with latest Emscripten and STANDALONE_WASM
 http_archive(
-    name = "com_google_absl",  # 2023-04-06T14:42:25Z
-    sha256 = "a50452f02402262f9a61a8eedda60f76dda6b9538d36b34b55bce9f74a4d5ef8",
-    strip_prefix = "abseil-cpp-e73b9139ee9b853a4bd7812531442c138da09084",
-    urls = ["https://github.com/abseil/abseil-cpp/archive/e73b9139ee9b853a4bd7812531442c138da09084.zip"],
+    name = "com_google_absl",  # 2024-03-06
+    sha256 = "bb5e84fc74362c546ab4193eeafd440a26487f4adf80587d2f2576f03c439c4b",
+    strip_prefix = "abseil-cpp-53e6dae02bf0d9a5a1d304a3d637c083376b86a1",
+    urls = ["https://github.com/abseil/abseil-cpp/archive/53e6dae02bf0d9a5a1d304a3d637c083376b86a1.zip"],
 )
 
-# Duplicate ProxyWasm WORKSPACE files (dependencies)
-# Consider adopting bzlmod for this: https://docs.bazel.build/versions/5.0.0/bzlmod.html
+# For testing, include Quiche for its Balsa header library.
+http_archive(
+    name = "com_github_google_quiche",  # 2024-05-16
+    patch_args = ["-p1"],
+    patches = ["//:quiche.patch"],
+    sha256 = "ae33ab0056fd5119d9aae15abfcb69e5d6f021ec5e18e77535ec0fe0c49dfa66",
+    strip_prefix = "quiche-1397c94d55af0bfc142ac7dda923cf2726857755",
+    urls = ["https://github.com/google/quiche/archive/1397c94d55af0bfc142ac7dda923cf2726857755.tar.gz"],
+)
+# Quiche dependency.
+http_archive(
+    name = "com_google_googleurl",  # 2022-11-03
+    sha256 = "59f14d4fb373083b9dc8d389f16bbb817b5f936d1d436aa67e16eb6936028a51",
+    urls = ["https://storage.googleapis.com/quiche-envoy-integration/dd4080fec0b443296c0ed0036e1e776df8813aa7.tar.gz"],
+)
 
+# Duplicate the ProxyWasm WORKSPACE files (dependencies)
+# Consider adopting bzlmod for this: https://docs.bazel.build/versions/5.0.0/bzlmod.html
 load("@proxy_wasm_cpp_host//bazel:repositories.bzl", "proxy_wasm_cpp_host_repositories")
 proxy_wasm_cpp_host_repositories()
 
@@ -87,12 +103,12 @@ load("@rules_rust//crate_universe:defs.bzl", "crates_repository")
 crates_repository(
     name = "crate_index",
     cargo_lockfile = "//:Cargo.lock",
+    # See https://github.com/GoogleCloudPlatform/service-extensions-samples/issues/31
+    generate_target_compatible_with = False,
     generator = "@cargo_bazel_bootstrap//:cargo-bazel",
     lockfile = "//:Cargo.Bazel.lock",
     manifests = ["//:Cargo.toml"],
     supported_platform_triples = ["wasm32-wasi"],
-    # See https://github.com/GoogleCloudPlatform/service-extensions-samples/issues/31
-    generate_target_compatible_with = False,
 )
 
 # Reference: @crate_index//:proxy-wasm (etc)

--- a/plugins/plugins.bzl
+++ b/plugins/plugins.bzl
@@ -38,6 +38,7 @@ def proxy_wasm_tests(
         name,
         tests,
         plugins = [],
+        data = [],
         config = None):
     """Generates cc_test targets for each provided wasm plugin.
 
@@ -45,6 +46,7 @@ def proxy_wasm_tests(
       name: Base name for the test targets.
       tests: TestSuite textproto config file that contains the tests to run.
       plugins: List of plugins (wasm build targets) to run tests on.
+      data: Supplementary inputs, such as test data payloads.
       config: Optional path to plugin config file.
     """
     for plugin in plugins:
@@ -55,7 +57,7 @@ def proxy_wasm_tests(
                 "--plugin=$(rootpath %s)" % plugin,
                 "--config=$(rootpath %s)" % config if config else "",
             ],
-            data = [tests, plugin] + ([config] if config else []),
+            data = [tests, plugin] + ([config] if config else []) + data,
             deps = ["//test:runner_lib"],
         )
 

--- a/plugins/quiche.patch
+++ b/plugins/quiche.patch
@@ -1,0 +1,13 @@
+diff --git a/quiche/BUILD.bazel b/quiche/BUILD.bazel
+index 39d0de2..efb58fb 100644
+--- a/quiche/BUILD.bazel
++++ b/quiche/BUILD.bazel
+@@ -34,7 +34,7 @@ load("//build:test.bzl", "test_suite_from_source_list")
+ licenses(["notice"])
+ 
+ package(
+-    default_visibility = ["//visibility:private"],
++    default_visibility = ["//visibility:public"],
+     features = [
+         "parse_headers",
+         "layering_check",

--- a/plugins/samples/testing/BUILD
+++ b/plugins/samples/testing/BUILD
@@ -1,0 +1,33 @@
+load("//:plugins.bzl", "proxy_wasm_plugin_cpp", "proxy_wasm_plugin_rust", "proxy_wasm_tests")
+
+licenses(["notice"])  # Apache 2
+
+proxy_wasm_plugin_rust(
+    name = "plugin_rust.wasm",
+    srcs = ["plugin.rs"],
+    deps = [
+        "@crate_index//:log",
+        "@crate_index//:proxy-wasm",
+    ],
+)
+
+proxy_wasm_plugin_cpp(
+    name = "plugin_cpp.wasm",
+    srcs = ["plugin.cc"],
+    deps = [
+        "@proxy_wasm_cpp_sdk//contrib:contrib_lib",
+    ],
+)
+
+proxy_wasm_tests(
+    name = "tests",
+    data = [
+        ":request_headers.data",
+        ":response_headers.data",
+    ],
+    plugins = [
+        ":plugin_cpp.wasm",
+        ":plugin_rust.wasm",
+    ],
+    tests = ":tests.textpb",
+)

--- a/plugins/samples/testing/plugin.cc
+++ b/plugins/samples/testing/plugin.cc
@@ -1,0 +1,71 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START serviceextensions_plugin_example_testing]
+#include "proxy_wasm_intrinsics.h"
+
+class MyHttpContext : public Context {
+ public:
+  explicit MyHttpContext(uint32_t id, RootContext* root) : Context(id, root) {}
+
+  FilterHeadersStatus onRequestHeaders(uint32_t headers,
+                                       bool end_of_stream) override {
+    LOG_DEBUG(std::string("request headers ") + std::to_string(id()));
+
+    // Emit headers to logs for debugging.
+    /*
+    auto result = getRequestHeaderPairs();
+    auto pairs = result->pairs();
+    LOG_INFO(std::string("num headers: ") + std::to_string(pairs.size()));
+    for (auto& p : pairs) {
+      LOG_INFO(std::string(p.first) + " -> " + std::string(p.second));
+    }
+    */
+    return FilterHeadersStatus::Continue;
+  }
+
+  FilterHeadersStatus onResponseHeaders(uint32_t headers,
+                                        bool end_of_stream) override {
+    LOG_DEBUG(std::string("response headers ") + std::to_string(id()));
+
+    // Emit headers to logs for debugging.
+    /*
+    auto result = getResponseHeaderPairs();
+    auto pairs = result->pairs();
+    LOG_INFO(std::string("num headers: ") + std::to_string(pairs.size()));
+    for (auto& p : pairs) {
+      LOG_INFO(std::string(p.first) + " -> " + std::string(p.second));
+    }
+    */
+
+    // Emit some timestamps.
+    for (int i = 1; i <= 3; ++i) {
+      using namespace std::chrono_literals;
+      const auto ts = std::chrono::high_resolution_clock::now();
+      const auto ns = ts.time_since_epoch() / 1ns;
+      LOG_INFO("time " + std::to_string(i) + ": " + std::to_string(ns));
+    }
+
+    // Conditionally reply with an error.
+    if (getResponseHeader("reply-with-error")->data()) {
+      sendLocalResponse(500, "extra", "fake error", {{"error", "goaway"}});
+      return FilterHeadersStatus::StopAllIterationAndWatermark;
+    }
+    return FilterHeadersStatus::Continue;
+  }
+};
+
+static RegisterContextFactory register_StaticContext(
+    CONTEXT_FACTORY(MyHttpContext), ROOT_FACTORY(RootContext));
+// [END serviceextensions_plugin_example_testing]

--- a/plugins/samples/testing/plugin.rs
+++ b/plugins/samples/testing/plugin.rs
@@ -1,0 +1,60 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START serviceextensions_plugin_example_testing]
+use log::*;
+use proxy_wasm::traits::*;
+use proxy_wasm::types::*;
+use std::time::SystemTime;
+
+proxy_wasm::main! {{
+    proxy_wasm::set_log_level(LogLevel::Trace);
+    proxy_wasm::set_http_context(|context_id: u32, _| -> Box<dyn HttpContext> {
+        Box::new(MyHttpContext { context_id })
+    });
+}}
+
+struct MyHttpContext {
+    context_id: u32,
+}
+
+impl Context for MyHttpContext {}
+
+impl HttpContext for MyHttpContext {
+    fn on_http_request_headers(&mut self, _: usize, _: bool) -> Action {
+        debug!("request headers {}", self.context_id);
+        return Action::Continue;
+    }
+
+    fn on_http_response_headers(&mut self, _: usize, _: bool) -> Action {
+        debug!("response headers {}", self.context_id);
+
+        // Emit some timestamps.
+        for i in 1..4 {
+            let ns = SystemTime::now()
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos();
+            info!("time {}: {}", i, ns);
+        }
+
+        // Conditionally reply with an error.
+        if self.get_http_response_header("reply-with-error").is_some() {
+            self.send_http_response(500, vec![("error", "goaway")], Some(b"fake error"));
+            return Action::Pause;
+        }
+        return Action::Continue;
+    }
+}
+// [END serviceextensions_plugin_example_testing]

--- a/plugins/samples/testing/request_headers.data
+++ b/plugins/samples/testing/request_headers.data
@@ -1,0 +1,4 @@
+GET https://example.com:8080/my/path?foo=bar HTTP/1.1
+Host: myhost.com
+MyHeader: MyVal1
+MyHeader: MyVal2

--- a/plugins/samples/testing/response_headers.data
+++ b/plugins/samples/testing/response_headers.data
@@ -1,0 +1,3 @@
+HTTP/1.1 403 Forbidden
+MyHeader: MyVal1
+MyHeader: MyVal2

--- a/plugins/samples/testing/tests.textpb
+++ b/plugins/samples/testing/tests.textpb
@@ -1,0 +1,110 @@
+env {
+  log_level: DEBUG  # aka --loglevel
+  log_path: "/dev/stdout"  # aka --logfile
+  time_secs: 123456789  # set clock
+}
+test {
+  name: "Headers_Proto"
+  request_headers {
+    input {
+      header { key: ":path" value: "/" }
+      header { key: ":method" value: "GET" }
+    }
+    result {
+      # Positive header matches.
+      has_header { key: ":path" value: "/" }
+      headers { exact: ":method: GET" }
+      # Negative header matches.
+      no_header { key: ":scheme" }
+      headers { regex: ":scheme:.*" invert: true }
+      # Logging matches.
+      log { regex: ".*request headers.*" }
+      log { regex: ".*response headers.*" invert: true }
+    }
+  }
+  response_headers {
+    input {
+      header { key: "server-message" value: "welcome" }
+      header { key: "reply-with-error" value: "yes" }
+    }
+    result {
+      # Immediate response matches.
+      immediate { http_status: 500 }
+      body { exact: "fake error" }
+      has_header { key: "error" value: "goaway" }
+      no_header { key: "server-message" }
+      # Log matches showing frozen time behavior.
+      log { regex: ".*time 1: 123456789000000000" }
+      log { regex: ".*time 2: 123456789000000000" }
+      log { regex: ".*time 3: 123456789000000000" }
+    }
+  }
+}
+test {
+  name: "Headers_Content"
+  request_headers {
+    # HTTP1 serialized request input, in origin form.
+    input {
+      content:
+        "GET /my/path?foo=bar HTTP/1.1\n"
+        "Host: myhost.com\n"
+        "MyHeader: MyVal1\n"
+        "MyHeader: MyVal2\n"
+    }
+    result {
+      has_header { key: ":method" value: "GET" }
+      has_header { key: ":path" value: "/my/path?foo=bar" }
+      has_header { key: ":authority" value: "myhost.com" }
+      no_header { key: "Host" }
+      has_header { key: "MyHeader" value: "MyVal1, MyVal2" }
+    }
+  }
+  response_headers {
+    # HTTP1 serialized response input, success.
+    input {
+      content:
+        "HTTP/1.1 200 OK\n"
+        "Content-Type: image/jpeg; charset=utf-8\n"
+        "MyHeader: MyVal1\n"
+        "MyHeader: MyVal2\n"
+    }
+    result {
+      has_header { key: ":status" value: "200" }
+      has_header { key: "MyHeader" value: "MyVal1, MyVal2" }
+    }
+  }
+}
+test {
+  name: "Headers_File"
+  request_headers {
+    # HTTP1 serialized request input, in absolute form, from file.
+    input {
+      # GET https://example.com:8080/my/path?foo=bar HTTP/1.1
+      # Host: myhost.com
+      # MyHeader: MyVal1
+      # MyHeader: MyVal2
+      file: "request_headers.data"
+    }
+    result {
+      has_header { key: ":method" value: "GET" }
+      has_header { key: ":path" value: "/my/path?foo=bar" }
+      has_header { key: ":scheme" value: "https" }
+      has_header { key: ":authority" value: "example.com:8080" }
+      no_header { key: "Host" }
+      has_header { key: "MyHeader" value: "MyVal1, MyVal2" }
+    }
+  }
+  response_headers {
+    # HTTP1 serialized response input, error, from file.
+    input {
+      # HTTP/1.1 403 Forbidden
+      # MyHeader: MyVal1
+      # MyHeader: MyVal2
+      file: "response_headers.data"
+    }
+    result {
+      has_header { key: ":status" value: "403" }
+      has_header { key: "MyHeader" value: "MyVal1, MyVal2" }
+    }
+  }
+}

--- a/plugins/samples/testing/tests.textpb
+++ b/plugins/samples/testing/tests.textpb
@@ -11,10 +11,10 @@ test {
       header { key: ":method" value: "GET" }
     }
     result {
-      # Positive header matches.
-      has_header { key: ":path" value: "/" }
+      # Positive header matches (two ways).
+      has_header { key: ":method" value: "GET" }
       headers { exact: ":method: GET" }
-      # Negative header matches.
+      # Negative header matches (two ways).
       no_header { key: ":scheme" }
       headers { regex: ":scheme:.*" invert: true }
       # Logging matches.
@@ -43,7 +43,7 @@ test {
 test {
   name: "Headers_Content"
   request_headers {
-    # HTTP1 serialized request input, in origin form.
+    # HTTP1 serialized request input, from string, in origin form.
     input {
       content:
         "GET /my/path?foo=bar HTTP/1.1\n"
@@ -60,7 +60,7 @@ test {
     }
   }
   response_headers {
-    # HTTP1 serialized response input, success.
+    # HTTP1 serialized response input, from string, denoting success.
     input {
       content:
         "HTTP/1.1 200 OK\n"
@@ -77,7 +77,7 @@ test {
 test {
   name: "Headers_File"
   request_headers {
-    # HTTP1 serialized request input, in absolute form, from file.
+    # HTTP1 serialized request input, from file, in absolute form.
     input {
       # GET https://example.com:8080/my/path?foo=bar HTTP/1.1
       # Host: myhost.com
@@ -95,7 +95,7 @@ test {
     }
   }
   response_headers {
-    # HTTP1 serialized response input, error, from file.
+    # HTTP1 serialized response input, from file, denoting error.
     input {
       # HTTP/1.1 403 Forbidden
       # MyHeader: MyVal1

--- a/plugins/test/BUILD
+++ b/plugins/test/BUILD
@@ -27,6 +27,7 @@ cc_library(
     deps = [
         ":framework",
         ":runner_cc_proto",
+        "@com_github_google_quiche//quiche:balsa",
         "@com_google_benchmark//:benchmark",
         "@com_google_googletest//:gtest",
         "@com_google_protobuf//:protobuf",

--- a/plugins/test/dynamic_test.cc
+++ b/plugins/test/dynamic_test.cc
@@ -453,9 +453,10 @@ absl::Status ParseHTTP1Headers(const std::string& content, bool is_request,
     hdrs.InsertOrAppend(":status", headers.response_code());
   }
 
-  // Emit normal headers to map, coalescing as we go.
+  // Emit normal headers to map, coalescing as we go. Convert header keys to
+  // lowercase like Envoy does. The wasm header map is also case insensitive.
   for (const auto& [key, value] : headers.lines()) {
-    hdrs.InsertOrAppend(key, value);
+    hdrs.InsertOrAppend(absl::AsciiStrToLower(key), value);
   }
   return absl::OkStatus();
 }

--- a/plugins/test/dynamic_test.cc
+++ b/plugins/test/dynamic_test.cc
@@ -16,12 +16,18 @@
 
 #include "test/dynamic_test.h"
 
+#include <boost/filesystem/path.hpp>
+
+#include "absl/strings/str_cat.h"
 #include "absl/strings/substitute.h"
 #include "benchmark/benchmark.h"
 #include "dynamic_test.h"
 #include "framework.h"
 #include "google/protobuf/text_format.h"
 #include "gtest/gtest.h"
+#include "quiche/balsa/balsa_frame.h"
+#include "quiche/balsa/balsa_headers.h"
+#include "quiche/common/platform/api/quiche_googleurl.h"
 #include "re2/re2.h"
 #include "test/framework.h"
 #include "test/runner.pb.h"
@@ -165,7 +171,9 @@ void DynamicTest::TestBody() {
   // Exercise phase tests in sequence.
   if (cfg_.has_request_headers()) {
     const auto& invoke = cfg_.request_headers();
-    auto res = stream.SendRequestHeaders(GenHeaders(invoke.input()));
+    auto headers = ParseHeaders(invoke.input(), /*is_request=*/true);
+    ASSERT_TRUE(headers.ok()) << headers.status();
+    auto res = stream.SendRequestHeaders(*headers);
     ASSERT_VM_HEALTH("request_headers", handle, stream);
     CheckPhaseResults("request_headers", invoke.result(), stream, res);
   }
@@ -174,7 +182,9 @@ void DynamicTest::TestBody() {
   }
   if (cfg_.has_response_headers()) {
     const auto& invoke = cfg_.response_headers();
-    auto res = stream.SendResponseHeaders(GenHeaders(invoke.input()));
+    auto headers = ParseHeaders(invoke.input(), /*is_request=*/false);
+    ASSERT_TRUE(headers.ok()) << headers.status();
+    auto res = stream.SendResponseHeaders(*headers);
     ASSERT_VM_HEALTH("response_headers", handle, stream);
     CheckPhaseResults("response_headers", invoke.result(), stream, res);
   }
@@ -260,11 +270,15 @@ void DynamicTest::BenchHttpHandlers(benchmark::State& state) {
   // Benchmark all configured HTTP handlers.
   std::optional<TestHttpContext::Headers> request_headers;
   if (cfg_.has_request_headers()) {
-    request_headers = GenHeaders(cfg_.request_headers().input());
+    auto headers = ParseHeaders(cfg_.request_headers().input(), true);
+    BM_RETURN_IF_ERROR(headers.status());
+    request_headers = *headers;
   }
   std::optional<TestHttpContext::Headers> response_headers;
   if (cfg_.has_response_headers()) {
-    response_headers = GenHeaders(cfg_.response_headers().input());
+    auto headers = ParseHeaders(cfg_.request_headers().input(), false);
+    BM_RETURN_IF_ERROR(headers.status());
+    response_headers = *headers;
   }
   for (auto _ : state) {
     if (request_headers) {
@@ -314,6 +328,16 @@ void DynamicTest::CheckPhaseResults(const std::string& phase,
       ADD_FAILURE() << absl::Substitute(
           "[$0] Header '$1' value is '$2', expected removed", phase,
           header.key(), it->second);
+    }
+  }
+  // Check serialized headers.
+  if (expect.headers_size() > 0) {
+    std::vector<std::string> headers;
+    for (const auto& kv : result.headers) {
+      headers.emplace_back(absl::StrCat(kv.first, ": ", kv.second));
+    }
+    for (const auto& match : expect.headers()) {
+      FindString(phase, "header", match, headers);
     }
   }
   // Check body content.
@@ -370,20 +394,104 @@ void DynamicTest::FindString(const std::string& phase, const std::string& type,
   }
   if (!matcher->Matches(contents)) {
     ADD_FAILURE() << absl::Substitute(
-        "[$0] expected $1 of $2 $3: '$4', actual: '$5'", phase,
+        "[$0] expected $1 of $2 $3: '$4', actual: \n$5", phase,
         expect.invert() ? "absence" : "presence",
         expect.has_regex() ? "regex" : "exact", type,
         expect.has_regex() ? expect.regex() : expect.exact(),
-        absl::StrJoin(contents, ","));
+        absl::StrJoin(contents, "\n"));
   }
 }
 
-TestHttpContext::Headers DynamicTest::GenHeaders(const pb::Input& input) {
+namespace {
+absl::Status ParseHTTP1Headers(const std::string& content, bool is_request,
+                               TestHttpContext::Headers& hdrs) {
+  const std::string end_headers = "\r\n\r\n";
+  quiche::BalsaHeaders headers;
+  quiche::BalsaFrame frame;
+  frame.set_balsa_headers(&headers);
+  frame.set_is_request(is_request);
+  frame.ProcessInput(content.c_str(), content.size());
+  frame.ProcessInput(end_headers.data(), end_headers.size());
+  if (frame.Error() ||
+      frame.ParseState() ==
+          quiche::BalsaFrameEnums::READING_HEADER_AND_FIRSTLINE) {
+    return absl::InvalidArgumentError(absl::StrCat(
+        "Header parse error: ",
+        quiche::BalsaFrameEnums::ErrorCodeToString(frame.ErrorCode())));
+  }
+
+  // Emit HTTP2 pseudo headers based on HTTP1 input.
+  if (is_request) {
+    hdrs.InsertOrAppend(":method", headers.request_method());
+    // Parse URI to see if it's in "absolute form" (scheme://host/path?query)
+    GURL uri(static_cast<std::string>(headers.request_uri()));
+    if (uri.is_valid()) {
+      // Emit everything from the URI.
+      hdrs.InsertOrAppend(":scheme", uri.scheme());
+      hdrs.InsertOrAppend(":path", uri.PathForRequest());
+      hdrs.InsertOrAppend(":authority",
+                          uri.IntPort() > 0
+                              ? absl::StrCat(uri.host(), ":", uri.IntPort())
+                              : uri.host());
+      headers.RemoveAllOfHeader("Host");
+    } else {
+      // Validate URI assuming "origin form" (absolute path and query only).
+      GURL base("http://example.com");
+      GURL join = base.Resolve(static_cast<std::string>(headers.request_uri()));
+      if (!join.is_valid() || join.PathForRequest() != headers.request_uri()) {
+        return absl::InvalidArgumentError(
+            absl::StrCat("Invalid URI: ", headers.request_uri()));
+      }
+      // Emit path as is. Emit authority if present. No scheme.
+      hdrs.InsertOrAppend(":path", headers.request_uri());
+      if (!headers.Authority().empty()) {
+        hdrs.InsertOrAppend(":authority", headers.Authority());
+        headers.RemoveAllOfHeader("Host");
+      }
+    }
+  } else {
+    hdrs.InsertOrAppend(":status", headers.response_code());
+  }
+
+  // Emit normal headers to map, coalescing as we go.
+  for (const auto& [key, value] : headers.lines()) {
+    hdrs.InsertOrAppend(key, value);
+  }
+  return absl::OkStatus();
+}
+}  // namespace
+
+absl::StatusOr<TestHttpContext::Headers> DynamicTest::ParseHeaders(
+    const pb::Input& input, bool is_request) {
   TestHttpContext::Headers hdrs;
-  for (const auto& header : input.header()) {
-    hdrs.emplace(header.key(), header.value());
+
+  if (!input.file().empty()) {
+    // Handle file input.
+    auto content = ReadContent(input.file());
+    if (!content.ok()) return content.status();
+    auto parse = ParseHTTP1Headers(*content, is_request, hdrs);
+    if (!parse.ok()) return parse;
+  } else if (!input.content().empty()) {
+    // Handle string input.
+    auto parse = ParseHTTP1Headers(input.content(), is_request, hdrs);
+    if (!parse.ok()) return parse;
+  } else {
+    // Handle proto input.
+    for (const auto& header : input.header()) {
+      hdrs.InsertOrAppend(header.key(), header.value());
+    }
   }
   return hdrs;
+}
+
+absl::StatusOr<std::string> DynamicTest::ReadContent(const std::string& path) {
+  boost::filesystem::path in(path);
+  boost::filesystem::path cfg(env_.test_path());
+  // If relative path, resolve relative to test config file.
+  if (!in.is_absolute()) {
+    in = cfg.parent_path() / in;
+  }
+  return ReadDataFile(in.string());
 }
 
 }  // namespace service_extensions_samples

--- a/plugins/test/dynamic_test.h
+++ b/plugins/test/dynamic_test.h
@@ -77,8 +77,11 @@ class DynamicTest : public DynamicFixture {
                   const pb::StringMatcher& expect,
                   const std::vector<std::string>& contents);
 
-  // Helper to generate Headers struct from proto.
-  TestHttpContext::Headers GenHeaders(const pb::Input& input);
+  // Helper to generate Headers struct from proto, string, or file.
+  absl::StatusOr<TestHttpContext::Headers> ParseHeaders(
+      const pb::Input& input, bool is_request);
+  // Helper to read data from a path which may be relative to the test config.
+  absl::StatusOr<std::string> ReadContent(const std::string& path);
 
   std::string engine_;
   pb::Env env_;

--- a/plugins/test/framework.cc
+++ b/plugins/test/framework.cc
@@ -16,6 +16,8 @@
 
 #include <boost/dll/runtime_symbol_info.hpp>
 
+#include "absl/strings/str_cat.h"
+
 namespace service_extensions_samples {
 
 proxy_wasm::BufferInterface* TestContext::getBuffer(
@@ -74,12 +76,7 @@ proxy_wasm::WasmResult TestHttpContext::addHeaderMapValue(
     proxy_wasm::WasmHeaderMapType type, std::string_view key,
     std::string_view value) {
   if (type != phase_) return proxy_wasm::WasmResult::BadArgument;
-  auto& val = result_.headers[std::string(key)];
-  if (val.empty()) {
-    val = std::string(value);
-  } else {
-    val = absl::StrCat(val, ", ", value);  // RFC 9110 Field Order
-  }
+  result_.headers.InsertOrAppend(key, value);
   return proxy_wasm::WasmResult::Ok;
 }
 proxy_wasm::WasmResult TestHttpContext::replaceHeaderMapValue(

--- a/plugins/test/package/licenses/LICENSE.googleurl
+++ b/plugins/test/package/licenses/LICENSE.googleurl
@@ -1,0 +1,27 @@
+// Copyright 2015 The Chromium Authors
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//    * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//    * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//    * Neither the name of Google LLC nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/plugins/test/package/licenses/LICENSE.quiche
+++ b/plugins/test/package/licenses/LICENSE.quiche
@@ -1,0 +1,27 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//    * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//    * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//    * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/plugins/test/package/licenses/README.md
+++ b/plugins/test/package/licenses/README.md
@@ -3,10 +3,12 @@ This directory contains licenses of open source software we package.
 The source materials are here:
 
 * ProxyWasm: https://github.com/proxy-wasm/proxy-wasm-cpp-host/blob/master/LICENSE
-* Google Chrome v8: https://chromium.googlesource.com/v8/v8.git/+/main/LICENSE
+* Google Chrome v8: https://github.com/v8/v8/blob/main/LICENSE
 * Google Benchmark: https://github.com/google/benchmark/blob/main/LICENSE
 * Google Test: https://github.com/google/googletest/blob/main/LICENSE
 * Google RE2: https://github.com/google/re2/blob/main/LICENSE
 * Protobuf: https://github.com/protocolbuffers/protobuf/blob/main/LICENSE
 * Abseil: https://github.com/abseil/abseil-cpp/blob/master/LICENSE
 * Boost: https://www.boost.org/LICENSE_1_0.txt
+* Google Quiche: https://github.com/google/quiche/blob/main/LICENSE
+* Google URL: https://github.com/chromium/chromium/blob/main/LICENSE

--- a/plugins/test/runner.proto
+++ b/plugins/test/runner.proto
@@ -35,15 +35,22 @@ message Header {
   bytes value = 2;
 }
 
+// Phase input. Only one of these fields may be provided.
 message Input {
   // Set of key-value headers. Includes pseudo-headers (e.g. :path).
   // Looking up header names (keys) is case-insensitive.
   repeated Header header = 1;
 
-  // HTTP BODY raw content.
-  // Consider supporting serialized HTTP headers using this field.
-  // For example: GET /my/path HTTP/1.1\r\nMyHeader: MyVal\r\n\r\n
+  // Serialized HTTP content for headers or body.
+  //
+  // Header input should be HTTP1. Wasm will receive HTTP2 headers.
+  //   Example: GET /my/path HTTP/1.1\r\nMyHeader: MyVal\r\n
+  //   Example: HTTP/1.1 200 OK\r\ncontent-length: 3\r\n
   bytes content = 2;
+
+  // Serialized HTTP content, but provided via a separate file.
+  // File path can be absolute or relative to the test config file.
+  string file = 3;
 }
 
 message Expectation {
@@ -51,10 +58,11 @@ message Expectation {
   repeated Header has_header = 1;
   // Headers expected to be missing. Values are ignored.
   repeated Header no_header = 2;
-  // NOTE: consider adding a generalized HeaderMatcher using 2 StringMatchers.
+  // Generalized header matching against serialized "key: value" lines.
+  repeated StringMatcher headers = 3;
 
-  // Body content accompanying an immediate response or invocation result.
-  repeated StringMatcher body = 3;
+  // Content accompanying an immediate response or body invocation result.
+  repeated StringMatcher body = 4;
 
   // Immediate response to the end user. No further invocations after this.
   message Immediate {
@@ -65,10 +73,10 @@ message Expectation {
     // Reason for immediate response. Used for error or debug logging.
     optional string details = 3;
   }
-  Immediate immediate = 4;
+  Immediate immediate = 5;
 
   // Side effect: logging.
-  repeated StringMatcher log = 5;
+  repeated StringMatcher log = 6;
 }
 
 message Invocation {
@@ -103,10 +111,12 @@ message Test {
 }
 
 message Env {
+  // Path to this config. Only used internally for input diagnostics.
+  string test_path = 1;
   // Path to compiled .wasm binary. Required.
-  string wasm_path = 1;
+  string wasm_path = 2;
   // Path to PluginConfiguration file.
-  string config_path = 2;
+  string config_path = 3;
   // Plugin min_log_level (tests assume 100% sampling).
   // Enum maps to proxy_wasm::LogLevel enum.
   enum LogLevel {
@@ -118,11 +128,11 @@ message Env {
     ERROR = 5;
     CRITICAL = 6;
   }
-  LogLevel log_level = 3;
+  LogLevel log_level = 4;
   // Log file to receive plugin output. Can be /dev/std{out,err}.
-  string log_path = 4;
+  string log_path = 5;
   // Fixed timestamp in Unix seconds. If unset it will be the Unix epoch.
-  uint64 time_secs = 5;
+  uint64 time_secs = 6;
 }
 
 message TestSuite {


### PR DESCRIPTION
Uses the Quiche Balsa library to parse HTTP1 headers and converts 
them into HTTP2 headers like ext_proc servers would see.

Also includes a large number of minor features and fixes:

- A testing showcase sample that exercises most test runner features
- An option to set the (fixed) host timestamp + tests for static time
- Generic string matching on serialized headers (key: value)
- Improve string matcher output format for clarity
- Supporting reading test files from relative paths
- A `--nobench` flag to turn off all benchmarking (faster iteration)
- Small fix to `--loglevel` flag overrides

Checks:

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR
