### PR TITLE
fix: Ensure new stream context is created for each benchmarking iteration

### DIFF
--- a/plugins/test/dynamic_test.cc
+++ b/plugins/test/dynamic_test.cc
@@ -281,6 +281,11 @@ void DynamicTest::BenchHttpHandlers(benchmark::State& state) {
     response_headers = *headers;
   }
   for (auto _ : state) {
+    // Initialize new stream for each iteration.
+    state.PauseTiming();
+    auto stream = TestHttpContext(handle);
+    BM_RETURN_IF_FAILED(handle);
+    state.ResumeTiming();
     if (request_headers) {
       auto res = stream.SendRequestHeaders(*request_headers);
       benchmark::DoNotOptimize(res);

--- a/plugins/test/dynamic_test.cc
+++ b/plugins/test/dynamic_test.cc
@@ -263,10 +263,6 @@ void DynamicTest::BenchHttpHandlers(benchmark::State& state) {
   BM_RETURN_IF_ERROR(plugin_init);
   BM_RETURN_IF_FAILED(handle);
 
-  // Initialize stream.
-  auto stream = TestHttpContext(handle);
-  BM_RETURN_IF_FAILED(handle);
-
   // Benchmark all configured HTTP handlers.
   std::optional<TestHttpContext::Headers> request_headers;
   if (cfg_.has_request_headers()) {


### PR DESCRIPTION
TestHttpContext is intended to live for a single request/response. We had an issue where multiple benchmark iterations were using the same context and this led to unintended behaviors. 
e.g: When a plugin had logic to exit immediately after completing a task, in subsequent iterations the plugin would exit as if the task had completed that iteration.
- [ ] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
